### PR TITLE
Bugfix/wbmodbus hotfixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.0.2) stable; urgency=medium
+
+  * Fixed fw_version length; Improved reading strings from modbus
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 03 Jun 2020 23:41:12 +0300
+
 wb-mcu-fw-updater (1.0.1) stable; urgency=medium
 
   * Fixed possible signature missmatch in some devices

--- a/debian/control
+++ b/debian/control
@@ -19,5 +19,5 @@ Description: Wiren Board modbus devices firmware update and modbus bindings pyth
 
 Package: wb-mcu-fw-updater
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater
+Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.2)
 Description: Wiren Board modbus devices firmware update tool (python 3)

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -31,7 +31,7 @@ def get_request_content(url_path):
 
 def get_fw_signatures_list():
     contents = get_request_content(CONFIG['FW_SIGNATURES_FILE_URL']).decode('utf-8')
-    return str(contents).split('\n')
+    return str(contents).strip().split('\n')
 
 
 class RemoteFileWatcher(object):
@@ -84,7 +84,7 @@ class RemoteFileWatcher(object):
         url_path = urljoin(self._construct_urlpath(name), CONFIG['LATEST_FW_VERSION_FILE'])
         try:
             content = get_request_content(url_path).decode('utf-8')
-            return content
+            return str(content).strip()
         except HTTPError as e:
             logging.error("Incorrect branch name or fw_signature!")
             die(e)

--- a/wb_modbus/__init__.py
+++ b/wb_modbus/__init__.py
@@ -11,6 +11,9 @@ ALLOWED_PARITIES = OrderedDict([('N', 0), ('O', 1), ('E', 2)])
 DEBUG = False
 
 
+WBMAP_MARKER = re.compile('\S*MAP\d+\S*')  # *MAP%d* matches
+
+
 def parse_uart_settings_str(settings_str):
     """
     A unified one-launchkey uart settings standart for Wiren Board software is like 9600N2

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -3,6 +3,7 @@
 #
 import logging
 import time
+from binascii import unhexlify
 from copy import deepcopy
 from itertools import product
 from functools import wraps
@@ -393,6 +394,7 @@ class MinimalModbusAPIWrapper(object):
     def read_string(self, addr, regs_lenght):
         """
         Reading a row of consecutive uint16 holding registers and interpreting row as a string.
+        Wiren Board devices store a placeholder + char per one u16 reg (ex: '\x00A1' or '\xFFA1' in some roms)
 
         :param addr: address of first register
         :type addr: int
@@ -401,8 +403,15 @@ class MinimalModbusAPIWrapper(object):
         :return: a string with cut trailing null-bytes
         :rtype: str
         """
-        ret = self.device.read_string(addr, regs_lenght, 3)
-        return str(ret).replace('\x00', '')
+        empty_chars_placeholders = ('00', 'FF', ' ')
+        ret = minimalmodbus._hexlify(self.device.read_string(addr, regs_lenght, 3))
+        for placeholder in empty_chars_placeholders:  # Clearing a string to only meaningful bytes
+            ret = ret.replace(placeholder, '')  # 'A1B2C3' bytes-only string
+        try:
+            return str(unhexlify(ret).decode('utf-8')).strip()
+        except UnicodeDecodeError as e:
+            logging.exception(e)
+            return None
 
 
 def auto_find_uart_settings(method_to_decorate):
@@ -447,14 +456,12 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
         'bootloader_version' : 330
     }
 
-    FIRMWARE_VERSION_LENGTH = 8
-    DEVICE_SIGNATURE_LENGTH = 6
-    FIRMWARE_SIGNATURE_LENGTH = 12
-    BOOTLOADER_VERSION_LENGTH = 7
+    FIRMWARE_VERSION_LENGTH = 16  # 250-265 u16 regs
+    DEVICE_SIGNATURE_LENGTH = 6  # 200-205 u16 regs
+    FIRMWARE_SIGNATURE_LENGTH = 12  # 290-301 u16 regs
+    BOOTLOADER_VERSION_LENGTH = 8  # 330-337 u16 regs
 
     SERIAL_TIMEOUT = 0.1
-
-    INTERNAL_STRINGS_CODING = 'utf-8'
 
     def __init__(self, addr, port, baudrate=9600, parity='N', stopbits=2):
         super(WBModbusDeviceBase, self).__init__(addr=addr, port=port, baudrate=baudrate, parity=parity, stopbits=stopbits)
@@ -505,8 +512,7 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
         return ((int_values[0] % 256) * 65536) + int_values[1]
 
     def get_fw_version(self):
-        ret = self.read_string(self.COMMON_REGS_MAP['fw_version'], self.FIRMWARE_VERSION_LENGTH)
-        return ret.encode().decode(self.INTERNAL_STRINGS_CODING).strip() #Python 2/3 compatibility
+        return self.read_string(self.COMMON_REGS_MAP['fw_version'], self.FIRMWARE_VERSION_LENGTH)
 
     def get_slave_addr(self):
         return self.read_u16(self.COMMON_REGS_MAP['slaveid'])
@@ -585,8 +591,7 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
         :return: device signature string
         :rtype: str
         """
-        ret = self.read_string(self.COMMON_REGS_MAP['device_signature'], self.DEVICE_SIGNATURE_LENGTH)
-        return ret.encode().decode(self.INTERNAL_STRINGS_CODING).strip() #Python 2/3 compatibility
+        return self.read_string(self.COMMON_REGS_MAP['device_signature'], self.DEVICE_SIGNATURE_LENGTH)
 
     def get_fw_signature(self):
         """
@@ -595,12 +600,10 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
         :return: firmware signature string
         :rtype: str
         """
-        ret = self.read_string(self.COMMON_REGS_MAP['fw_signature'], self.FIRMWARE_SIGNATURE_LENGTH)
-        return ret.encode().decode(self.INTERNAL_STRINGS_CODING).strip() #Python 2/3 compatibility
+        return self.read_string(self.COMMON_REGS_MAP['fw_signature'], self.FIRMWARE_SIGNATURE_LENGTH)
 
     def get_bootloader_version(self):
-        ret = self.read_string(self.COMMON_REGS_MAP['bootloader_version'], self.BOOTLOADER_VERSION_LENGTH)
-        return ret.encode().decode(self.INTERNAL_STRINGS_CODING).strip() #Python 2/3 compatibility
+        return self.read_string(self.COMMON_REGS_MAP['bootloader_version'], self.BOOTLOADER_VERSION_LENGTH - 1)  # The last char is STM type
 
     def get_uptime(self):
         """

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -6,7 +6,7 @@ import time
 from copy import deepcopy
 from itertools import product
 from functools import wraps
-from . import minimalmodbus, ALLOWED_UNSUCCESSFUL_TRIES, CLOSE_PORT_AFTER_EACH_CALL, ALLOWED_PARITIES, ALLOWED_BAUDRATES, ALLOWED_STOPBITS, DEBUG
+from . import minimalmodbus, ALLOWED_UNSUCCESSFUL_TRIES, CLOSE_PORT_AFTER_EACH_CALL, ALLOWED_PARITIES, ALLOWED_BAUDRATES, ALLOWED_STOPBITS, DEBUG, WBMAP_MARKER
 
 
 def force(errtypes=(minimalmodbus.ModbusException, ValueError), tries=ALLOWED_UNSUCCESSFUL_TRIES):
@@ -493,7 +493,9 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
         :return: serial number of device
         :rtype: int
         """
-        if self.get_device_signature().startswith('WBMAP'):
+        device_signature = str(self.get_device_signature())
+        if WBMAP_MARKER.match(device_signature):
+            logging.debug('Will calculate SN as WB-MAP*')
             return self._get_serial_number_map()
         else:
             return self.read_u32_big_endian(self.COMMON_REGS_MAP['serial_number'])


### PR DESCRIPTION
Вылезло при переводе тест-сьюта/калибровки мапов:

1. Серийник мапов. Откуда я взял WBMAP в сигнатуре устройства - непонятно. Теперь ищем regexp'ом `MAP%d`
2. Чтение строчки из регистров. Символы у нас хранятся по одному на u16 регистр (кстати, почему, если влезает 2?). Пример: `\x00A1, \x00B2` и `\x0000, \x0000` там, где строчка короче отведённого под неё числа регистров. Всё было хорошо до MCM8 (у него пустые символы не `\x0000`, а `\x00FF`; Никита в курсе) => аккуратно вырезаем 00 и FF
3. В загрузчике прошивки обрезаем строчку везде, кроме загрузки файла прошивки/бутлоадера
4. Длина версии прошивки - 16 регистров (смотрели с Никитой)