### PR TITLE
Feature/25532 usability improvements

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.0.4) stable; urgency=medium
+
+  * Restoring initial serial port settings
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 08 Jun 2020 17:08:21 +0300
+
 wb-mcu-fw-updater (1.0.3) stable; urgency=medium
 
   * Too-old-for-update devices are showing explicitly

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.0.3) stable; urgency=medium
+
+  * Too-old-for-update devices are showing explicitly
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 08 Jun 2020 14:44:52 +0300
+
 wb-mcu-fw-updater (1.0.2) stable; urgency=medium
 
   * Fixed fw_version length; Improved reading strings from modbus

--- a/debian/control
+++ b/debian/control
@@ -19,5 +19,5 @@ Description: Wiren Board modbus devices firmware update and modbus bindings pyth
 
 Package: wb-mcu-fw-updater
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.2)
+Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.3)
 Description: Wiren Board modbus devices firmware update tool (python 3)

--- a/debian/control
+++ b/debian/control
@@ -19,5 +19,5 @@ Description: Wiren Board modbus devices firmware update and modbus bindings pyth
 
 Package: wb-mcu-fw-updater
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.3)
+Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.4)
 Description: Wiren Board modbus devices firmware update tool (python 3)

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -14,7 +14,7 @@ def update_fw(args):
     Updating device's firmware.
     Could install specified fw_version from specified branch.
     """
-    modbus_connection = update_monitor.get_correct_modbus_connection(args.slaveid, args.port, args.uart_settings, args.unknown_uart_settings)
+    modbus_connection = update_monitor.get_correct_modbus_connection(args.slaveid, args.port)
     try:
         update_monitor.flash_alive_device(modbus_connection, 'fw', args.branch_name, args.specified_version, args.force, args.erase_settings)
         logging.info('%s' % user_log.colorize('Done', 'GREEN'))
@@ -34,7 +34,7 @@ def update_bootloader(args):
     Only latest version from stable branch is available.
     """
     update_monitor.ask_user("Updating bootloader is a dangerous operation.  Some device settings will be erased.\nIt may brick the device and void the warranty! Are you sure?")
-    modbus_connection = update_monitor.get_correct_modbus_connection(args.slaveid, args.port, args.uart_settings, args.unknown_uart_settings)
+    modbus_connection = update_monitor.get_correct_modbus_connection(args.slaveid, args.port)
     try:
         update_monitor.flash_alive_device(modbus_connection, 'bootloader', '', 'latest', args.force, erase_settings=False)
         logging.info('%s' % user_log.colorize('Done', 'GREEN'))
@@ -64,7 +64,7 @@ def recover_fw(args):  # TODO: add check, is device in bootloader or not
     if args.slaveid != 0:  # A broadcast-connected device does not answer to in-bootloader-probing cmd
         device = WBModbusDeviceBase(args.slaveid, args.port)
         if not device.is_in_bootloader():
-            die("Device (%s : %d) is not in bootloader mode!\nCheck device's connection or slaveid/port")
+            die("Device (%s : %d) is not in bootloader mode!\nCheck device's connection or slaveid/port" % (args.port, args.slaveid))
 
     fw_signatures_list = fw_downloader.get_fw_signatures_list()
 
@@ -122,10 +122,6 @@ def parse_args():
                                   default='latest', help='Download a specified firmware version. (Default: %(default)s)')
     update_fw_parser.add_argument('--restore-defaults', action='store_true', dest='erase_settings',
                                   default=False, help="Erase all device's settings during update. (Default: %(default)s)")
-    update_fw_parser.add_argument('--port-settings', metavar='<port_settings_str>', type=str, dest='uart_settings',
-                                  default='9600N2', help='Serial port settings string. (Default: %(default)s)')
-    update_fw_parser.add_argument('--find-port-settings', action='store_true', dest='unknown_uart_settings',
-                                  default=False, help='Automatically find serial port settings of device. (Default: %(default)s)')
     update_fw_parser.add_argument('-f', '--force', action='store_true', dest='force', default=False,
                                   help='Perform force device reflash, even if firmware is latest. (Default: %(default)s)')
     update_fw_parser.add_argument(
@@ -139,10 +135,6 @@ def parse_args():
     """
     update_bootloader_parser = subparsers.add_parser(
         'update-bl', help='Update bootloader on single working device.')
-    update_bootloader_parser.add_argument('--port-settings', type=str, metavar='<port_settings_str>', dest='uart_settings',
-                                          default='9600N2', help='Serial port settings string. (Default: %(default)s)')
-    update_bootloader_parser.add_argument('--find-port-settings', action='store_true', dest='unknown_uart_settings',
-                                          default=False, help='Automatically find serial port settings of device. (Default: %(default)s)')
     update_bootloader_parser.add_argument('-f', '--force', action='store_true', dest='force', default=False,
                                           help='Perform force device reflash, even if firmware is latest. (Default: %(default)s)')
     update_bootloader_parser.add_argument(

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -6,6 +6,7 @@ import logging
 import atexit
 from subprocess import CalledProcessError
 from wb_mcu_fw_updater import fw_downloader, update_monitor, user_log, die, CONFIG
+from wb_modbus.bindings import WBModbusDeviceBase
 
 
 def update_fw(args):
@@ -47,7 +48,7 @@ def update_bootloader(args):
         die(e)
 
 
-def recover_fw(args):
+def recover_fw(args):  # TODO: add check, is device in bootloader or not
     """
     Recovering the device, stuck in the bootloader
     """
@@ -59,6 +60,11 @@ def recover_fw(args):
         except (CalledProcessError, RuntimeError) as e:
             logging.exception(e)
             return False
+
+    if args.slaveid != 0:  # A broadcast-connected device does not answer to in-bootloader-probing cmd
+        device = WBModbusDeviceBase(args.slaveid, args.port)
+        if not device.is_in_bootloader():
+            die("Device (%s : %d) is not in bootloader mode!\nCheck device's connection or slaveid/port")
 
     fw_signatures_list = fw_downloader.get_fw_signatures_list()
 
@@ -72,14 +78,15 @@ def recover_fw(args):
         if fw_signature:
             if _flash_in_bl(fw_signature, args.slaveid, args.port):
                 return
-        for fw_sig in fw_signatures_list:  # No fw_signatures in db or stored one was unsuccessful
-            logging.info('Trying %s:' % fw_sig)
-            if _flash_in_bl(fw_sig, args.slaveid, args.port):
-                return
-        die('No one from all possible fw_signatures has succeed!\nPossibly, device (%d : %s) is disconnected or slaveid is wrong.' % (args.slaveid, args.port))
+        if update_monitor.ask_user('Try all possible signatures (%s) on port %s and slaveid %d?' % (', '.join(fw_signatures_list), args.port, args.slaveid)):
+            for fw_sig in fw_signatures_list:  # No fw_signatures in db or stored one was unsuccessful
+                logging.info('Trying %s:' % fw_sig)
+                if _flash_in_bl(fw_sig, args.slaveid, args.port):
+                    return
+        die('Recovering the device (%d : %s) was not successful' % (args.slaveid, args.port))
 
     else:
-        die('Choose a fw_signature from : %s' % (', '.join(fw_signatures_list))) #DO NOT use argparse's choices! (logging could be incorrect)
+        die('Choose a fw_signature from allowed: %s' % (', '.join(fw_signatures_list))) #DO NOT use argparse's choices! (logging could be incorrect)
 
 
 def update_all(args):

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -56,7 +56,7 @@ def recover_fw(args):
             update_monitor.recover_device_iteration(fw_sig, slaveid, port)
             logging.info('%s' % user_log.colorize('Done', 'GREEN'))
             return True
-        except CalledProcessError as e:
+        except (CalledProcessError, RuntimeError) as e:
             logging.exception(e)
             return False
 

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -182,4 +182,8 @@ if __name__ == "__main__":
     atexit.register(update_monitor.resume_driver)
     atexit.register(update_monitor.db.dump)
 
+    if 'port' in vars(args):
+        initial_port_settings = update_monitor.get_port_settings(args.port)
+        atexit.register(lambda: update_monitor.set_port_settings(args.port, initial_port_settings))
+
     args.func(args)

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -67,6 +67,8 @@ def recover_fw(args):  # TODO: add check, is device in bootloader or not
             die("Device (%s : %d) is not in bootloader mode!\nCheck device's connection or slaveid/port" % (args.port, args.slaveid))
 
     fw_signatures_list = fw_downloader.get_fw_signatures_list()
+    if fw_signatures_list is None:
+        die('Unable to get allowed fw_signatures')
 
     if args.known_signature in fw_signatures_list:  # fw_signature was specified manually
         if not _flash_in_bl(args.known_signature, args.slaveid, args.port):

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -49,26 +49,35 @@ def update_bootloader(args):
 
 def recover_fw(args):
     """
-    Recovering the device, stuck in the bootloader by already known fw_signature.
+    Recovering the device, stuck in the bootloader
     """
+    def _flash_in_bl(fw_sig, slaveid, port):
+        try:
+            update_monitor.recover_device_iteration(fw_sig, slaveid, port)
+            logging.info('%s' % user_log.colorize('Done', 'GREEN'))
+            return True
+        except CalledProcessError as e:
+            logging.exception(e)
+            return False
+
     fw_signatures_list = fw_downloader.get_fw_signatures_list()
-    if args.known_signature is None:
-        logging.warning("Restoring device's fw_signature from db by slaveid: %d and port %s" % (args.slaveid, args.port))
+
+    if args.known_signature in fw_signatures_list:  # fw_signature was specified manually
+        if not _flash_in_bl(args.known_signature, args.slaveid, args.port):
+            die()
+
+    elif args.known_signature is None:  # A default value from args
+        logging.debug("Will try to restore fw_signature from db by slaveid: %d and port %s" % (args.slaveid, args.port))
         fw_signature = update_monitor.db.get_fw_signature(args.slaveid, args.port)
         if fw_signature:
-            try:
-                update_monitor.recover_device_iteration(fw_signature, args.slaveid, args.port)
-                logging.info('%s' % user_log.colorize('Done', 'GREEN'))
-            except CalledProcessError as e:
-                die(e)
-        else:
-            die('No data for device (%d : %s) has found. Specify fw_signature manually via --fw-sig key!' % (args.slaveid, args.port))
-    elif args.known_signature in fw_signatures_list:
-        try:
-            update_monitor.recover_device_iteration(args.known_signature, args.slaveid, args.port)
-            logging.info('%s' % user_log.colorize('Done', 'GREEN'))
-        except CalledProcessError as e:
-            die(e)
+            if _flash_in_bl(fw_signature, args.slaveid, args.port):
+                return
+        for fw_sig in fw_signatures_list:  # No fw_signatures in db or stored one was unsuccessful
+            logging.info('Trying %s:' % fw_sig)
+            if _flash_in_bl(fw_sig, args.slaveid, args.port):
+                return
+        die('No one from all possible fw_signatures has succeed!\nPossibly, device (%d : %s) is disconnected or slaveid is wrong.' % (args.slaveid, args.port))
+
     else:
         die('Choose a fw_signature from : %s' % (', '.join(fw_signatures_list))) #DO NOT use argparse's choices! (logging could be incorrect)
 

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -17,6 +17,8 @@ def update_fw(args):
     try:
         update_monitor.flash_alive_device(modbus_connection, 'fw', args.branch_name, args.specified_version, args.force, args.erase_settings)
         logging.info('%s' % user_log.colorize('Done', 'GREEN'))
+    except update_monitor.TooOldDeviceError as e:
+        die(e)
     except update_monitor.ModbusError as e:
         logging.error("Check device's connection, slaveid and serial port settings!")
         die(e)
@@ -35,6 +37,8 @@ def update_bootloader(args):
     try:
         update_monitor.flash_alive_device(modbus_connection, 'bootloader', '', 'latest', args.force, erase_settings=False)
         logging.info('%s' % user_log.colorize('Done', 'GREEN'))
+    except update_monitor.TooOldDeviceError as e:
+        die(e)
     except update_monitor.ModbusError as e:
         logging.error("Check device's connection, slaveid and serial port settings!")
         die(e)

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -100,7 +100,7 @@ class RemoteFileWatcher(object):
         :param fname: custom path, file will be saved, defaults to None
         :type fname: str, optional
         :return: path of saved file
-        :rtype: str
+        :rtype: str (if succeed) or None (if not)
         """
         fw_ver = '%s%s' % (version, CONFIG['FW_EXTENSION'])
         url_path = urljoin(self._construct_urlpath(name), fw_ver)
@@ -112,7 +112,8 @@ class RemoteFileWatcher(object):
                 version,
                 self.branch_name
             ))
-            die(e)
+            logging.exception(e)
+            return None
         file_saving_dir = os.path.join(CONFIG['FW_SAVING_DIR'], self.mode)
         if not fname:
             if not os.path.isdir(file_saving_dir):
@@ -127,5 +128,6 @@ class RemoteFileWatcher(object):
             fh.write(content)
             fh.close()
         except PermissionError as e:
-            die(e)
+            logging.exception(e)
+            return None
         return fpath

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -30,8 +30,12 @@ def get_request_content(url_path):
 
 
 def get_fw_signatures_list():
-    contents = get_request_content(CONFIG['FW_SIGNATURES_FILE_URL']).decode('utf-8')
-    return str(contents).strip().split('\n')
+    try:
+        contents = get_request_content(CONFIG['FW_SIGNATURES_FILE_URL']).decode('utf-8')
+        return str(contents).strip().split('\n')
+    except (URLError, HTTPError) as e:
+        logging.exception(e)
+        return None
 
 
 class RemoteFileWatcher(object):

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -86,8 +86,8 @@ class RemoteFileWatcher(object):
             content = get_request_content(url_path).decode('utf-8')
             return str(content).strip()
         except HTTPError as e:
-            logging.error("Incorrect branch name or fw_signature!")
-            die(e)
+            logging.error("Not Found: %s" % url_path)
+            return None
 
     def download(self, name, version='latest', fname=None):
         """

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -371,7 +371,6 @@ def _recover_all():
     ))
 
 
-
 def _send_signal_to_driver(signal):
     """
     Use pausing/resuming of process, found by name (instead of killing/starting)

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import termios
 import json
 from json.decoder import JSONDecodeError
 import subprocess
@@ -361,3 +362,24 @@ def pause_driver():
 
 def resume_driver():
     _send_signal_to_driver('-CONT')
+
+
+def get_port_settings(port_fname):
+    """
+    python-serial does not remember initial port settings (bd, parity, etc...)
+    => restoring it manually after all operations to let wb-mqtt-serial work again
+    """
+    try:
+        with open(port_fname) as port:
+            fd = port.fileno()
+            return termios.tcgetattr(fd)
+    except Exception as e:
+        die(e)
+
+
+def set_port_settings(port_fname, termios_settings):
+    try:
+        with open(port_fname) as port:
+            termios.tcsetattr(port.fileno(), termios.TCSANOW, termios_settings)
+    except Exception as e:
+        die(e)

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -237,6 +237,7 @@ def probe_all_devices(driver_config_fname):
                     modbus_connection.get_slave_addr()
                 except ModbusError: # Device is really disconnected
                     disconnected.append(store_device(device_name, device_slaveid, port, uart_params))
+                    continue
                 try:
                     db.save(modbus_connection.slaveid, modbus_connection.port, modbus_connection.get_fw_signature()) # old devices haven't fw_signatures
                     alive.append(store_device(device_name, device_slaveid, port, uart_params))

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -44,28 +44,18 @@ def ask_user(message):
     return ret.upper().startswith('Y')
 
 
-
-def get_correct_modbus_connection(slaveid, port, uart_settings_str, uart_settings_are_unknown):
+def get_correct_modbus_connection(slaveid, port):
     if slaveid == 0:
         die("Slaveid %d is not allowed in this mode!" % slaveid)  # Broadcast slaveid is available only in bootloader to prevent possible harm
     modbus_connection = bindings.WBModbusDeviceBase(slaveid, port)
     try:
-        uart_settings = parse_uart_settings_str(uart_settings_str)
-        modbus_connection.set_port_settings(*uart_settings)
+        logging.info("Will find serial port settings for (%s : %d)..." % (port, slaveid))
+        uart_settings_dict = modbus_connection.find_uart_settings(modbus_connection.get_slave_addr)
     except RuntimeError as e:
-        die(e)
-    if uart_settings_are_unknown:
-        """
-        Applying found uart settings to modbus_connection instance.
-        """
-        try:
-            logging.warning("Serial port settings are unknown. Trying to find it...")
-            uart_settings_dict = modbus_connection.find_uart_settings(modbus_connection.get_slave_addr)
-        except RuntimeError as e:
-            logging.error('Device is disconnected or slaveid is wrong')
-            die(e)
-        logging.info('Has found serial port settings: %s' % str(uart_settings_dict))
-        modbus_connection._set_port_settings_raw(uart_settings_dict)
+        logging.error('Device is disconnected or slaveid/port is wrong')
+        die()
+    logging.info('Has found serial port settings: %s' % str(uart_settings_dict))
+    modbus_connection._set_port_settings_raw(uart_settings_dict)
     return modbus_connection
 
 
@@ -328,7 +318,7 @@ def _update_all(force):
 
 
 def _recover_all():
-    alive, in_bootloader, dummy_records = probe_all_devices(CONFIG['SERIAL_DRIVER_CONFIG_FNAME'])
+    alive, in_bootloader, dummy_records, _ = probe_all_devices(CONFIG['SERIAL_DRIVER_CONFIG_FNAME'])
     recover_was_skipped = []
     to_recover = []
     ok_records = []

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -14,8 +14,6 @@ class TooOldDeviceError(minimalmodbus.ModbusException):
     """
     Some Wiren Board devices do not support in-filed firmware upudate, because they haven't bootloader.
     """
-    def __init__(self, value):
-        logging.error('%s: %s' % (self.__class__.__name__, repr(value)))
 
 
 def force(errtypes=(minimalmodbus.ModbusException, ValueError), tries=ALLOWED_UNSUCCESSFUL_TRIES):


### PR DESCRIPTION
- Перед началом работы запоминаем настройки порта, а в конце - восстанавливаем (termios)
- Убраны ключи --port-settings и --find-port-settings из режимов update. Теперь ищем настройки порта всегда. Если slaveid указан неверно, пробежать по всем настройкам - 5 секунд. Зато, убрали 2 флага запуска и необходимость пользователю думать о настройках порта
- В режиме "recover" если fw_signature не была задана явно и восстановить устройство не получилось, предлагаем попробвать все возможные fw_signatures
- Распознаём слишком старые устройства и явно говорим пользователю об этом