### PR TITLE
Feature/modbus patching

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.0.5) stable; urgency=medium
+
+  * Ability to use custom minimalmodbus instances in wb_modbus library
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 6 Jul 2020 20:18:11 +0300
+
 wb-mcu-fw-updater (1.0.4) stable; urgency=medium
 
   * Restoring initial serial port settings

--- a/debian/control
+++ b/debian/control
@@ -19,5 +19,5 @@ Description: Wiren Board modbus devices firmware update and modbus bindings pyth
 
 Package: wb-mcu-fw-updater
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.4)
+Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.5)
 Description: Wiren Board modbus devices firmware update tool (python 3)

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -52,9 +52,9 @@ def recover_fw(args):  # TODO: add check, is device in bootloader or not
     """
     Recovering the device, stuck in the bootloader
     """
-    def _flash_in_bl(fw_sig, slaveid, port):
+    def _flash_in_bl(fw_sig, slaveid, port, custom_speed=None):
         try:
-            update_monitor.recover_device_iteration(fw_sig, slaveid, port)
+            update_monitor.recover_device_iteration(fw_sig, slaveid, port, custom_bl_speed=custom_speed)
             logging.info('%s' % user_log.colorize('Done', 'GREEN'))
             return True
         except (CalledProcessError, RuntimeError) as e:
@@ -71,19 +71,19 @@ def recover_fw(args):  # TODO: add check, is device in bootloader or not
         die('Unable to get allowed fw_signatures')
 
     if args.known_signature in fw_signatures_list:  # fw_signature was specified manually
-        if not _flash_in_bl(args.known_signature, args.slaveid, args.port):
+        if not _flash_in_bl(args.known_signature, args.slaveid, args.port, args.custom_bl_speed):
             die()
 
     elif args.known_signature is None:  # A default value from args
         logging.debug("Will try to restore fw_signature from db by slaveid: %d and port %s" % (args.slaveid, args.port))
         fw_signature = update_monitor.db.get_fw_signature(args.slaveid, args.port)
         if fw_signature:
-            if _flash_in_bl(fw_signature, args.slaveid, args.port):
+            if _flash_in_bl(fw_signature, args.slaveid, args.port, args.custom_bl_speed):
                 return
         if update_monitor.ask_user('Try all possible signatures (%s) on port %s and slaveid %d?' % (', '.join(fw_signatures_list), args.port, args.slaveid)):
             for fw_sig in fw_signatures_list:  # No fw_signatures in db or stored one was unsuccessful
                 logging.info('Trying %s:' % fw_sig)
-                if _flash_in_bl(fw_sig, args.slaveid, args.port):
+                if _flash_in_bl(fw_sig, args.slaveid, args.port, args.custom_bl_speed):
                     return
         die('Recovering the device (%d : %s) was not successful' % (args.slaveid, args.port))
 
@@ -154,6 +154,7 @@ def parse_args():
                                    help="Force specify device's firmware signature. (Default: %(default)s)")
     recover_fw_parser.add_argument('--restore-defaults', action='store_true', dest='erase_settings',
                                    default=False, help="Erase all device's settings during flashing. (Default: %(default)s)")
+    recover_fw_parser.add_argument('-B', dest='custom_bl_speed', type=int, default=None, help=argparse.SUPPRESS)  # A hidden arg for internal usage
     recover_fw_parser.add_argument(
         '-a', '--slaveid', type=int, dest='slaveid', metavar='<slaveid>', required=True, help='Slave address of the device.')
     recover_fw_parser.add_argument(

--- a/wb_mcu_fw_updater/fw_flasher.py
+++ b/wb_mcu_fw_updater/fw_flasher.py
@@ -27,7 +27,7 @@ class WBFWFlasher(object):
             self.out_buffer = sys.stdout.buffer
 
 
-    def flash(self, slaveid, fpath, restore_defaults=False, response_timeout=2.0):
+    def flash(self, slaveid, fpath, restore_defaults=False, response_timeout=2.0, custom_bl_speed=None):
         """Flashing .wbfw file via constructing and calling wb-mcu-fw-flasher command.
 
         :param slaveid: slave addr of device
@@ -45,6 +45,8 @@ class WBFWFlasher(object):
             die('FW file %s not found!' % fpath)
         cmd_args = self.known_cmd_args[::]
         cmd_args.extend(['-a', str(slaveid), '-f', fpath, '-t', str(response_timeout)])
+        if custom_bl_speed:
+            cmd_args.extend(['-B', str(custom_bl_speed)])
         if restore_defaults:
             cmd_args.append('-e')
         logging.debug('Will run: %s' % str(cmd_args))

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -88,23 +88,23 @@ def get_devices_on_driver(driver_config_fname):
         die('No devices has found in %s' % driver_config_fname)
 
 
-def recover_device_iteration(fw_signature, slaveid, port, response_timeout=2.0):
+def recover_device_iteration(fw_signature, slaveid, port, response_timeout=2.0, custom_bl_speed=None):
     downloader = fw_downloader.RemoteFileWatcher(mode='fw', branch_name='')
     fw_version = 'latest'
     downloaded_fw = downloader.download(fw_signature, fw_version)
     if downloaded_fw is None:
         raise RuntimeError('FW file was not downloaded!')
-    flash_in_bootloader(downloaded_fw, slaveid, port, erase_settings=False, response_timeout=response_timeout)
+    flash_in_bootloader(downloaded_fw, slaveid, port, erase_settings=False, response_timeout=response_timeout, custom_bl_speed=custom_bl_speed)
 
 
-def flash_in_bootloader(downloaded_fw_fpath, slaveid, port, erase_settings, response_timeout=2.0):
+def flash_in_bootloader(downloaded_fw_fpath, slaveid, port, erase_settings, response_timeout=2.0, custom_bl_speed=None):
     if erase_settings:
         if ask_user('All settings will be reset to defaults (1, 9600-8-N-2). Are you sure?'):
             pass
         else:
             die('Reset of settings was rejected')
     flasher = fw_flasher.WBFWFlasher(port)
-    flasher.flash(slaveid, downloaded_fw_fpath, erase_settings, response_timeout)
+    flasher.flash(slaveid, downloaded_fw_fpath, erase_settings, response_timeout, custom_bl_speed)
 
 
 def flash_alive_device(modbus_connection, mode, branch_name, specified_fw_version, force, erase_settings):

--- a/wb_modbus/minimalmodbus.py
+++ b/wb_modbus/minimalmodbus.py
@@ -94,7 +94,7 @@ _ALL_PAYLOADFORMATS = [
 # ######################## #
 
 
-class Instrument:
+class Instrument(object):
     """Instrument class for talking to instruments (slaves).
 
     Uses the Modbus RTU or ASCII protocols (via RS485 or RS232).


### PR DESCRIPTION
Нужно для bus77:
1) нашим обёрткам вокруг modbus можно подсовывать кастомный Instrument
2) работает super для minimalmodbus.Instrument в питоне2
3) сделал скрытый ключик запуска -B <in_bootloader_baudrate> для апдейтера (дёргает флешер с соответствующим скрытым ключом). Бывает нужен на производстве; в теории - может пригодиться клиентам