### PR TITLE
opening wb-mqtt-serial's config in utf-8 by default

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.0.6) stable; urgency=medium
+
+  * Wb-mqtt-serial's config is opening in utf-8 by default
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 19 Oct 2020 12:02:39 +0300
+
 wb-mcu-fw-updater (1.0.5) stable; urgency=medium
 
   * Ability to use custom minimalmodbus instances in wb_modbus library

--- a/debian/control
+++ b/debian/control
@@ -19,5 +19,5 @@ Description: Wiren Board modbus devices firmware update and modbus bindings pyth
 
 Package: wb-mcu-fw-updater
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.5)
+Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.6)
 Description: Wiren Board modbus devices firmware update tool (python 3)

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -68,7 +68,7 @@ def get_devices_on_driver(driver_config_fname):
     """
     found_devices = {}
     try:
-        config_dict = json.load(open(driver_config_fname, 'r'))
+        config_dict = json.load(open(driver_config_fname, 'r', encoding='utf-8'))
     except (IOError, JSONDecodeError) as e:
         die(e)
     for port in config_dict['ports']:


### PR DESCRIPTION
Проблема оказалась в отдельно взятом контроллере. На нём куда-то делась переменная окружения LANG (почему так произошло - отдельный вопрос, кстати). 
А хитрый python выбирает кодировку для открытия файла, исходя из неё (и берёт ascii, если ничего нет), если ему не сказать прямо => задаём utf-8