### PR TITLE
fixed python3 dependency in wb5

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.0.7) stable; urgency=medium
+
+  * Fixed python3 dependency in WB5
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 11 Feb 2021 14:37:12 +0300
+
 wb-mcu-fw-updater (1.0.6) stable; urgency=medium
 
   * Wb-mqtt-serial's config is opening in utf-8 by default

--- a/debian/control
+++ b/debian/control
@@ -14,10 +14,10 @@ Description: Wiren Board modbus devices firmware update and modbus bindings pyth
 
 Package: python3-wb-mcu-fw-updater
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-serial, wb-mcu-fw-flasher (>= 1.0.7)
+Depends: ${python3:Depends} | python3.5, ${misc:Depends}, python3-serial, wb-mcu-fw-flasher (>= 1.0.7)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 3)
 
 Package: wb-mcu-fw-updater
 Architecture: all
-Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.6)
+Depends: ${misc:Depends}, python3-wb-mcu-fw-updater (>= 1.0.7)
 Description: Wiren Board modbus devices firmware update tool (python 3)


### PR DESCRIPTION
На WB5 была проблема с установкой апдейтера: пакет с python3 стал называться python3.5

Кажется, в wb-mcu-fw-updater зависимость от питона лишняя, т.к. он зависит от python3-wb-mcu-fw-updater (в свою очередь, зависящего от питона). На wb5, wb6 всё ставится, удаляется, как надо (удаление питона3 тянет за собой python3-wb-mcu-fw-updater и wb-mcu-fw-updater)