### PR TITLE
build-depends on py2 or py3 instead of both

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-wb-mcu-fw-updater (1.0.10) stable; urgency=medium
+wb-mcu-fw-updater (1.0.11) stable; urgency=medium
+
+  * updated build-depends: on python2 or python3 (instead of both)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Sun, 01 Aug 2021 11:41:21 +0300
+
+wwb-mcu-fw-updater (1.0.10) stable; urgency=medium
 
   * trying to read fw_signature from bootloader in all recover cases
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Vladimir Romanov <v.romanov@wirenboard.ru>
 Section: python
 Priority: optional
 XS-Python-Version: >= 2.7
-Build-Depends: python, dh-python, python-setuptools, debhelper (>= 9), python3, python3-setuptools
+Build-Depends: python | python3, python-setuptools | python3-setuptools, dh-python, debhelper (>= 9)
 Standards-Version: 3.9.1
 X-Python-Version: >= 2.7
 

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Description: Wiren Board modbus devices firmware update and modbus bindings pyth
 
 Package: python3-wb-mcu-fw-updater
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-serial, wb-mcu-fw-flasher (>= 1.0.7)
+Depends: python3 (<< 3.6) | python3 (>= 3.6), python3 (<< 3.6) | python3-distutils, ${misc:Depends}, python3-serial, wb-mcu-fw-flasher (>= 1.0.7)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 3)
 
 Package: wb-mcu-fw-updater


### PR DESCRIPTION
Обновил на ноуте debian до bullseye; перестал собираться апдейтер (из-за того, что выпилили некоторые python2-пакеты). 

Теперь все собирается на:
моем ноуте с bullseye
ноуте с ubuntu 18.04
дженкинсе