### PR TITLE
fix issue #13: Unhandled exception in update_all

### DIFF
--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -77,6 +77,8 @@ def get_devices_on_driver(driver_config_fname):
             uart_params_of_port = [int(port['baud_rate']), port['parity'], int(port['stop_bits'])]
             devices_on_port = set()
             for serial_device in port['devices']:
+                if not serial_device.get('enabled', True):
+                    continue;
                 device_name = serial_device.get('device_type', 'Unknown')
                 slaveid = serial_device['slave_id']
                 if device_name.startswith('WBIO-'):


### PR DESCRIPTION
get_devices_on_driver(): skip polling of devices with attribute enabled set to false