### PR TITLE
Feature/releases support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.0.11) stable; urgency=medium
+
+  * trying to guess default fw version from releases
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 16 Nov 2021 11:00:31 +0300
+
 wb-mcu-fw-updater (1.0.10) stable; urgency=medium
 
   * trying to read fw_signature from bootloader in all recover cases

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-wb-mcu-fw-updater (1.0.11) stable; urgency=medium
+wb-mcu-fw-updater (1.1.0) stable; urgency=medium
 
-  * trying to guess default fw version from releases
+  * added fw releases support: trying to guess target fw version from releases, when updating fw
 
- -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 16 Nov 2021 11:00:31 +0300
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 12 Jan 2022 15:55:29 +0300
 
 wb-mcu-fw-updater (1.0.10) stable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -9,12 +9,12 @@ X-Python-Version: >= 2.7
 
 Package: python-wb-mcu-fw-updater
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, python-serial, wb-mcu-fw-flasher (>= 1.0.7)
+Depends: ${python:Depends}, ${misc:Depends}, python-serial, python-yaml, wb-mcu-fw-flasher (>= 1.0.7)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 2)
 
 Package: python3-wb-mcu-fw-updater
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-serial, wb-mcu-fw-flasher (>= 1.0.7)
+Depends: python3, ${misc:Depends}, python3-serial, python3-yaml, wb-mcu-fw-flasher (>= 1.0.7)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 3)
 
 Package: wb-mcu-fw-updater

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Vladimir Romanov <v.romanov@wirenboard.ru>
 Section: python
 Priority: optional
 XS-Python-Version: >= 2.7
-Build-Depends: python | python3, dh-python, python-setuptools | python3-setuptools, debhelper (>= 9)
+Build-Depends: python, dh-python, python-setuptools, debhelper (>= 9), python3, python3-setuptools
 Standards-Version: 3.9.1
 X-Python-Version: >= 2.7
 

--- a/debian/control
+++ b/debian/control
@@ -19,5 +19,5 @@ Description: Wiren Board modbus devices firmware update and modbus bindings pyth
 
 Package: wb-mcu-fw-updater
 Architecture: all
-Depends: ${misc:Depends}, python3-wb-mcu-fw-updater (= ${binary:Version})
+Depends: ${misc:Depends}, python3-wb-mcu-fw-updater (= ${binary:Version}), wb-release-info
 Description: Wiren Board modbus devices firmware update tool (python 3)

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Maintainer: Vladimir Romanov <v.romanov@wirenboard.ru>
 Section: python
 Priority: optional
 XS-Python-Version: >= 2.7
-Build-Depends: python, dh-python, python-setuptools, debhelper (>= 9), python3, python3-setuptools
+Build-Depends: python | python3, dh-python, python-setuptools | python3-setuptools, debhelper (>= 9)
 Standards-Version: 3.9.1
 X-Python-Version: >= 2.7
 

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -5,7 +5,7 @@ import argparse
 import logging
 import atexit
 from subprocess import CalledProcessError
-from wb_mcu_fw_updater import fw_downloader, update_monitor, user_log, releases, die, CONFIG
+from wb_mcu_fw_updater import fw_downloader, update_monitor, user_log, die, CONFIG
 from wb_modbus.bindings import WBModbusDeviceBase
 
 
@@ -196,12 +196,7 @@ if __name__ == "__main__":
     atexit.register(update_monitor.resume_driver)
     atexit.register(update_monitor.db.dump)
 
-    releases_fname = CONFIG['RELEASES_FNAME']
-    try:
-        update_monitor.RELEASE_INFO = releases.parse_releases(releases_fname)
-    except Exception as e:
-        logging.error("Critical error in %s file!\nContact the support!" % releases_fname)
-        raise e
+    update_monitor.fill_release_info()
 
     if 'port' in vars(args):
         initial_port_settings = update_monitor.get_port_settings(args.port)

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -5,7 +5,7 @@ import argparse
 import logging
 import atexit
 from subprocess import CalledProcessError
-from wb_mcu_fw_updater import fw_downloader, update_monitor, user_log, die, CONFIG
+from wb_mcu_fw_updater import fw_downloader, update_monitor, user_log, releases, die, CONFIG
 from wb_modbus.bindings import WBModbusDeviceBase
 
 
@@ -193,6 +193,8 @@ if __name__ == "__main__":
     update_monitor.pause_driver()
     atexit.register(update_monitor.resume_driver)
     atexit.register(update_monitor.db.dump)
+
+    update_monitor.RELEASE_INFO = releases.parse_releases()
 
     if 'port' in vars(args):
         initial_port_settings = update_monitor.get_port_settings(args.port)

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -81,7 +81,7 @@ def recover_fw(args):
                 return
 
         # No fw_signature has provided
-        if update_monitor.ask_user('Try all possible signatures (%s) on port %s and slaveid %d?' % (', '.join(fw_signatures_list), args.port, args.slaveid)):
+        elif update_monitor.ask_user('Try all possible signatures (%s) on port %s and slaveid %d?' % (', '.join(fw_signatures_list), args.port, args.slaveid)):
             for fw_sig in fw_signatures_list:  # No fw_signatures in db or stored one was unsuccessful
                 logging.info('Trying %s:' % fw_sig)
                 if _flash_in_bl(fw_sig, args.slaveid, args.port, args.custom_bl_speed):

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -96,7 +96,7 @@ def update_all(args):
     """
     Updating firmwares for all devices, specified in wb-mqtt-serial's config.
     """
-    update_monitor._update_all(force=args.force)
+    update_monitor._update_all(force=args.force, allow_downgrade=args.allow_downgrade)
 
 
 def recover_all(args):
@@ -168,7 +168,9 @@ def parse_args():
     update_all_fw_parser = subparsers.add_parser(
         'update-all', help="Trying to update firmwares on all devices, added to wb-mqtt-serial's config.")
     update_all_fw_parser.add_argument('-f', '--force', action='store_true', dest='force', default=False,
-                                      help='Perform force updates of all devices, even if firmwares are latest. (Default: %(default)s)')
+                                    help='Perform force updates of all devices, even if firmwares are latest. (Default: %(default)s)')
+    update_all_fw_parser.add_argument('--allow-downgrade', action='store_true', dest='allow_downgrade', default=False,
+                                    help='Firmware versions could be downgraded. (Default: %(default)s)')
     update_all_fw_parser.set_defaults(func=update_all)
 
     recover_all_parser = subparsers.add_parser(

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -122,7 +122,7 @@ def parse_args():
     update_fw_parser.add_argument('--branch', type=str, dest='branch_name', metavar='<branch_name>', default='',
                                   help='Install firmware from specified branch. (Default: %(default)s)')
     update_fw_parser.add_argument('--version', type=str, dest='specified_version', metavar='<fw_version>',
-                                  default='latest', help='Download a specified firmware version. (Default: %(default)s)')
+                                  default='release', help='Download a specified firmware version. (Default: %(default)s)')
     update_fw_parser.add_argument('--restore-defaults', action='store_true', dest='erase_settings',
                                   default=False, help="Erase all device's settings during update. (Default: %(default)s)")
     update_fw_parser.add_argument('-f', '--force', action='store_true', dest='force', default=False,

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -194,7 +194,12 @@ if __name__ == "__main__":
     atexit.register(update_monitor.resume_driver)
     atexit.register(update_monitor.db.dump)
 
-    update_monitor.RELEASE_INFO = releases.parse_releases()
+    releases_fname = CONFIG['RELEASES_FNAME']
+    try:
+        update_monitor.RELEASE_INFO = releases.parse_releases(releases_fname)
+    except Exception as e:
+        logging.error("Critical error in %s file!\nContact the support!" % releases_fname)
+        raise e
 
     if 'port' in vars(args):
         initial_port_settings = update_monitor.get_port_settings(args.port)

--- a/wb_mcu_fw_updater/__init__.py
+++ b/wb_mcu_fw_updater/__init__.py
@@ -38,8 +38,8 @@ CONFIG = {
 
     # fw-releases.wirenboard.com endpoints
     'ROOT_URL' : 'http://fw-releases.wirenboard.com/',
-    'FW_SIGNATURES_FILE_URL' : 'http://fw-releases.wirenboard.com/fw/by-signature/fw_signatures.txt',
-    'FW_RELEASES_FILE_URL' : 'http://fw-releases.wirenboard.com/fw/by-signature/release-versions.yaml',
+    'FW_SIGNATURES_FILE_URI' : 'fw/by-signature/fw_signatures.txt',
+    'FW_RELEASES_FILE_URI' : 'fw/by-signature/release-versions.yaml',
 }
 
 

--- a/wb_mcu_fw_updater/__init__.py
+++ b/wb_mcu_fw_updater/__init__.py
@@ -23,8 +23,6 @@ CONFIG = {
     'SERIAL_DRIVER_PROCESS_NAME' : 'wb-mqtt-serial',
     'SERIAL_DRIVER_CONFIG_FNAME' : '/etc/wb-mqtt-serial.conf',
     'FLASHER_EXEC_NAME' : 'wb-mcu-fw-flasher',
-    'ROOT_URL' : 'http://fw-releases.wirenboard.com/',
-    'FW_SIGNATURES_FILE_URL' : 'http://fw-releases.wirenboard.com/fw/by-signature/fw_signatures.txt',
     'FW_SAVING_DIR' : '/var/lib/wb-mcu-fw-updater/',
     'FW_EXTENSION' : '.wbfw',
     'LATEST_FW_VERSION_FILE' : 'latest.txt',
@@ -35,7 +33,13 @@ CONFIG = {
     'SYSLOG_LOGLEVEL' : 10,
     'USER_LOGLEVEL' : 30,
     'MAX_DB_RECORDS' : 100,
-    'DB_FILE_LOCATION' : '/var/lib/wb-mcu-fw-updater/devices.jsondb'
+    'DB_FILE_LOCATION' : '/var/lib/wb-mcu-fw-updater/devices.jsondb',
+    'RELEASES_FNAME' : '/usr/lib/wb-release',
+
+    # fw-releases.wirenboard.com endpoints
+    'ROOT_URL' : 'http://fw-releases.wirenboard.com/',
+    'FW_SIGNATURES_FILE_URL' : 'http://fw-releases.wirenboard.com/fw/by-signature/fw_signatures.txt',
+    'FW_RELEASES_FILE_URL' : 'http://fw-releases.wirenboard.com/fw/by-signature/release-versions.yaml',
 }
 
 

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -3,7 +3,7 @@
 
 import logging
 import os
-from posixpath import join as urljoin
+from posixpath import join as urljoin  # py2/3 compatibility
 from . import PYTHON2, CONFIG, die
 
 if PYTHON2:
@@ -146,4 +146,4 @@ class RemoteFileWatcher(object):
                 version,
                 self.branch_name
             ))
-            raise e
+            raise

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -48,11 +48,7 @@ def get_fw_signatures_list():
 
 def download_file(url_path, saving_dir=None, fname=None):
     ret = get_request(url_path)
-    if ret:
-        content = ret.read()
-    else:
-        logging.error("Could not download from %s" % url_path)
-        return None
+    content = ret.read()
 
     saving_dir = saving_dir or CONFIG['FW_SAVING_DIR']
     if not fname:
@@ -142,13 +138,12 @@ class RemoteFileWatcher(object):
             file_saving_dir = os.path.join(CONFIG['FW_SAVING_DIR'], self.mode)
             os.makedirs(file_saving_dir, exist_ok=True)
 
-        saved_fpath = download_file(url_path, file_saving_dir)
-        if saved_fpath:
-            return saved_fpath
-        else:
-            logging.error('Could not download fw: signature %s, version %s, branch %s' % (
+        try:
+            return download_file(url_path, file_saving_dir)
+        except Exception as e:
+            logging.error('Could not download: signature %s, version %s, branch %s' % (
                 name,
                 version,
                 self.branch_name
             ))
-            return None
+            raise e

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -28,7 +28,7 @@ def get_request(url_path):
         responce = url_handler.urlopen(url_path)
         return responce
     except (URLError, HTTPError) as e:
-        logging.exception()
+        logging.exception(url_path)
         return None
 
 

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -37,12 +37,12 @@ def get_string(url_path, coding='utf-8'):
     return str(ret.read().decode(coding)).strip() if ret else None
 
 
-def get_releases_info(remote_fname=CONFIG['FW_RELEASES_FILE_URL']):
+def get_release_versions(remote_fname=urljoin(CONFIG['ROOT_URL'], CONFIG['FW_RELEASES_FILE_URI'])):
     return get_string(remote_fname)
 
 
 def get_fw_signatures_list():
-    ret = get_string(CONFIG['FW_SIGNATURES_FILE_URL'])
+    ret = get_string(urljoin(CONFIG['ROOT_URL'], CONFIG['FW_SIGNATURES_FILE_URI']))
     return ret.split('\n') if ret else None
 
 
@@ -67,14 +67,9 @@ def download_file(url_path, saving_dir=None, fname=None):
         logging.error("Fname to save fw was not specified")
         return None
 
-    try:
-        fh = open(file_path, 'wb+')
+    with open(file_path, 'wb+') as fh:
         fh.write(content)
-        fh.close()
         return file_path
-    except OSError as e:
-        logging.exception()
-        return None
 
 
 class RemoteFileWatcher(object):
@@ -145,8 +140,7 @@ class RemoteFileWatcher(object):
 
         if not fpath:
             file_saving_dir = os.path.join(CONFIG['FW_SAVING_DIR'], self.mode)
-            if not os.path.isdir(file_saving_dir):
-                os.mkdir(file_saving_dir)
+            os.makedirs(file_saving_dir, exist_ok=True)
 
         saved_fpath = download_file(url_path, file_saving_dir)
         if saved_fpath:

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -3,6 +3,7 @@
 
 import logging
 import os
+import errno
 from posixpath import join as urljoin  # py2/3 compatibility
 from . import PYTHON2, CONFIG, die
 
@@ -136,8 +137,11 @@ class RemoteFileWatcher(object):
 
         if not fpath:
             file_saving_dir = os.path.join(CONFIG['FW_SAVING_DIR'], self.mode)
-            os.makedirs(file_saving_dir, exist_ok=True)
-
+            try:
+                os.makedirs(file_saving_dir)  # py2 has not exist_ok param
+            except OSError as e:
+                if e.errno != errno.EEXIST:
+                    raise
         try:
             return download_file(url_path, file_saving_dir)
         except Exception as e:

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -38,6 +38,15 @@ def get_fw_signatures_list():
         return None
 
 
+def get_releases_info(remote_fname=CONFIG['FW_RELEASES_FILE_URL']):
+    try:
+        contents = get_request_content(remote_fname).decode('utf-8')
+        return str(contents).strip()
+    except (URLError, HTTPError) as e:
+        logging.exception(e)
+        return None
+
+
 class RemoteFileWatcher(object):
     """
     A class, downloading Firmware or Bootloader, found by device_signature or project_name from remote server.

--- a/wb_mcu_fw_updater/releases.py
+++ b/wb_mcu_fw_updater/releases.py
@@ -29,10 +29,7 @@ def parse_releases(fname=CONFIG['RELEASES_FNAME']):
     return ret
 
 
-RELEASE_INFO = parse_releases()
-
-
-def get_release_file_urls(release_info=RELEASE_INFO, default_releases_file_url=CONFIG['FW_RELEASES_FILE_URL']):
+def get_release_file_urls(release_info, default_releases_file_url=CONFIG['FW_RELEASES_FILE_URL']):
     """
     Returns a list of remote release-file urls: [with-repo-prefix (if exists), default]
     """

--- a/wb_mcu_fw_updater/releases.py
+++ b/wb_mcu_fw_updater/releases.py
@@ -17,11 +17,11 @@ def parse_releases(fname=CONFIG['RELEASES_FNAME']):
         TARGET
         REPO_PREFIX
     """
-    ret = defaultdict(default_factory=lambda: None)
+    ret = defaultdict(lambda: None)
 
     logging.debug("Reading %s for releases info" % fname)
     if os.path.exists(fname):
-        ret = {k.strip(): v.strip() for k, v in (l.split('=', 1) for l in open(fname))}
+        ret.update({k.strip(): v.strip() for k, v in (l.split('=', 1) for l in open(fname))})
         logging.debug("Got releases info:\n%s" % str(ret))
     else:
         logging.warning("Releases file %s not found" % fname)

--- a/wb_mcu_fw_updater/releases.py
+++ b/wb_mcu_fw_updater/releases.py
@@ -39,6 +39,7 @@ def get_release_file_urls(release_info, default_releases_file_url=CONFIG['FW_REL
         fname_suffix = re.sub('[\W_]+', '~', fname_suffix)  # changing non letters or numbers to ~
         ret.append(default_releases_file_url.replace('.yaml', '.%s.yaml' % fname_suffix))
     ret.append(default_releases_file_url)
+    logging.debug("FW releases files: %s" % str(ret))
     return ret
 
 

--- a/wb_mcu_fw_updater/releases.py
+++ b/wb_mcu_fw_updater/releases.py
@@ -40,3 +40,17 @@ def get_release_file_urls(release_info, default_releases_file_url=CONFIG['FW_REL
         ret.append(default_releases_file_url.replace('.yaml', '.%s.yaml' % fname_suffix))
     ret.append(default_releases_file_url)
     return ret
+
+
+def parse_fw_version(endpoint_url):
+    """
+    Parsing fw version from endpoint url, stored in releases file
+    """
+    extension = CONFIG['FW_EXTENSION']
+    re_str = '.+/(.+)%s' % extension
+    mat = re.match(re_str, endpoint_url)  # matches .../*.wbfw
+    if mat:
+        return mat.group(1)
+    else:
+        logging.warning("Could not parse fw version from %s by regexp %s" % (endpoint_url, re_str))
+        return None

--- a/wb_mcu_fw_updater/releases.py
+++ b/wb_mcu_fw_updater/releases.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging
+import os
+import re
+from collections import defaultdict
+from . import CONFIG
+
+
+def parse_releases(fname=CONFIG['RELEASES_FNAME']):
+    """
+    WirenBoard controllers have releases info, stored in file <CONFIG['RELEASES_FNAME']>
+    Releases info file usually contains:
+        RELEASE_NAME
+        SUITE
+        TARGET
+        REPO_PREFIX
+    """
+    ret = defaultdict(default_factory=lambda: None)
+
+    logging.debug("Reading %s for releases info" % fname)
+    if os.path.exists(fname):
+        ret = {k: v for k, v in (l.split('=', 1) for l in open(fname))}
+        logging.debug("Got releases info:\n%s" % str(ret))
+    else:
+        logging.warning("Releases file %s not found" % fname)
+
+    return ret
+
+
+RELEASE_INFO = parse_releases()
+
+
+def get_release_file_urls(release_info=RELEASE_INFO, default_releases_file_url=CONFIG['FW_RELEASES_FILE_URL']):
+    """
+    Returns a list of remote release-file urls: [with-repo-prefix (if exists), default]
+    """
+    ret = []
+    fname_suffix = release_info['REPO_PREFIX']
+    if fname_suffix:
+        fname_suffix = re.sub('[\W_]+', '~', fname_suffix)  # changing non letters or numbers to ~
+        ret.append(default_releases_file_url.replace('.yaml', '.%s.yaml' % fname_suffix))
+    ret.append(default_releases_file_url)
+    return ret

--- a/wb_mcu_fw_updater/releases.py
+++ b/wb_mcu_fw_updater/releases.py
@@ -21,7 +21,7 @@ def parse_releases(fname=CONFIG['RELEASES_FNAME']):
 
     logging.debug("Reading %s for releases info" % fname)
     if os.path.exists(fname):
-        ret = {k: v for k, v in (l.split('=', 1) for l in open(fname))}
+        ret = {k.strip(): v.strip() for k, v in (l.split('=', 1) for l in open(fname))}
         logging.debug("Got releases info:\n%s" % str(ret))
     else:
         logging.warning("Releases file %s not found" % fname)

--- a/wb_mcu_fw_updater/releases.py
+++ b/wb_mcu_fw_updater/releases.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 from collections import defaultdict
+from posixpath import join as urljoin
 from . import CONFIG
 
 
@@ -29,7 +30,7 @@ def parse_releases(fname=CONFIG['RELEASES_FNAME']):
     return ret
 
 
-def get_release_file_urls(release_info, default_releases_file_url=CONFIG['FW_RELEASES_FILE_URL']):
+def get_release_file_urls(release_info, default_releases_file_url=urljoin(CONFIG['ROOT_URL'], CONFIG['FW_RELEASES_FILE_URI'])):
     """
     Returns a list of remote release-file urls: [with-repo-prefix (if exists), default]
     """

--- a/wb_mcu_fw_updater/releases.py
+++ b/wb_mcu_fw_updater/releases.py
@@ -9,7 +9,7 @@ from posixpath import join as urljoin
 from . import CONFIG
 
 
-def parse_releases(fname=CONFIG['RELEASES_FNAME']):
+def parse_releases(fname=CONFIG['RELEASES_FNAME']):  # TODO: look at wb-update-manager package
     """
     WirenBoard controllers have releases info, stored in file <CONFIG['RELEASES_FNAME']>
     Releases info file usually contains:
@@ -21,13 +21,10 @@ def parse_releases(fname=CONFIG['RELEASES_FNAME']):
     ret = defaultdict(lambda: None)
 
     logging.debug("Reading %s for releases info" % fname)
-    if os.path.exists(fname):
-        ret.update({k.strip(): v.strip() for k, v in (l.split('=', 1) for l in open(fname))})
+    with open(fname) as fp:
+        ret.update({k.strip(): v.strip() for k, v in (l.split('=', 1) for l in fp)})
         logging.debug("Got releases info:\n%s" % str(ret))
-    else:
-        logging.warning("Releases file %s not found" % fname)
-
-    return ret
+        return ret
 
 
 def get_release_file_urls(release_info, default_releases_file_url=urljoin(CONFIG['ROOT_URL'], CONFIG['FW_RELEASES_FILE_URI'])):

--- a/wb_mcu_fw_updater/releases.py
+++ b/wb_mcu_fw_updater/releases.py
@@ -5,7 +5,7 @@ import logging
 import os
 import re
 from collections import defaultdict
-from posixpath import join as urljoin
+from posixpath import join as urljoin  # py2/3 compatibility
 from . import CONFIG
 
 

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -5,7 +5,6 @@ import logging
 import termios
 import json
 import yaml
-from json.decoder import JSONDecodeError
 import subprocess
 from pprint import pformat
 from distutils.version import LooseVersion
@@ -21,7 +20,9 @@ from wb_modbus import minimalmodbus, bindings, parse_uart_settings_str
 
 if PYTHON2:
     input_func = raw_input
+    JSONDecodeError = ValueError  # py2 raises ValueError instead of JSONDecodeError
 else:
+    from json.decoder import JSONDecodeError
     input_func = input
 
 

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
 import logging
 import termios
 import json
@@ -55,9 +54,10 @@ def fill_release_info():  # TODO: make a class, storing a release-info context
     wb-mcu-fw-updater supposed to be launched only on devices, supporting wb-releases
     incorrect wb-releases file indicates strange erroneous behavior
     """
+    global RELEASE_INFO
     releases_fname = CONFIG['RELEASES_FNAME']
     try:
-        sys.modules[__name__].RELEASE_INFO = releases.parse_releases(releases_fname)  # instead of global
+        RELEASE_INFO = releases.parse_releases(releases_fname)
     except Exception as e:
         logging.error("Critical error in %s file!\nContact the support!" % releases_fname)
         raise

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -72,9 +72,6 @@ def get_released_fw(fw_signature, release_info):
 
 
 def download_fw_fallback(fw_signature, release_info):
-    if not release_info:
-        return fw_downloader.RemoteFileWatcher('fw', branch_name='').download(fw_signature, 'latest')
-
     downloaded_fw = None
     _, released_fw_endpoint = get_released_fw(fw_signature, release_info)
     if released_fw_endpoint:
@@ -311,9 +308,6 @@ def probe_all_devices(driver_config_fname):
 
 
 def _update_all(force):  # TODO: maybe store fw endpoint in device_info? (to prevent multiple releases-parsing)
-    if not RELEASE_INFO:
-        die('"update-all" mode works only for releases!\nPossible solutions:\n\trun "apt update; apt upgrade" and migrate to releases system\n\tmanually update each device "wb-mcu-fw-updater update-fw -a <Addr> <Port> --version latest"')
-
     alive, in_bootloader, dummy_records, too_old_devices = probe_all_devices(CONFIG['SERIAL_DRIVER_CONFIG_FNAME'])
     ok_records = []
     update_was_skipped = [] # Device_info dicts

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -48,17 +48,19 @@ def ask_user(message):
     return ret.upper().startswith('Y')
 
 
-def get_released_fw_version(fw_signature, release_info):
+def get_released_fw(fw_signature, release_info):
     for url in releases.get_release_file_urls(release_info):
+        suite = release_info['SUITE']
         contents = fw_downloader.get_releases_info(url)
         if contents:
-            ret = safe_load(contents).get('releases')
-            ret = ret.get(fw_signature).get(release_info['SUITE'])
-            if ret:
-                logging.debug("FW version for %s on release %s: %s")
-                return ret
+            fw_endpoint = safe_load(contents).get('releases')
+            fw_endpoint = fw_endpoint.get(fw_signature).get(suite)
+            if fw_endpoint:
+                fw_version = releases.parse_fw_version(fw_endpoint)
+                logging.debug("FW version for %s on release %s: %s\nEndpoint: %s" % (fw_signature, suite, fw_version, fw_endpoint))
+                return fw_version, fw_endpoint
     else:
-        return None
+        return None, None
 
 
 def get_correct_modbus_connection(slaveid, port):
@@ -110,7 +112,7 @@ def get_devices_on_driver(driver_config_fname):
 
 def recover_device_iteration(fw_signature, slaveid, port, response_timeout=2.0, custom_bl_speed=None):
     downloader = fw_downloader.RemoteFileWatcher(mode='fw', branch_name='')
-    fw_version = get_released_fw_version(fw_signature, RELEASE_INFO) or 'latest'
+    fw_version, _ = get_released_fw(fw_signature, RELEASE_INFO) or 'latest'
     downloaded_fw = downloader.download(fw_signature, fw_version)
     if downloaded_fw is None:
         raise RuntimeError('FW file was not downloaded!')
@@ -163,7 +165,7 @@ def flash_alive_device(modbus_connection, mode, branch_name, specified_fw_versio
         # logging.debug('Retrieving latest %s version number for %s' % (mode_name, fw_signature))
         specified_fw_version = downloader.get_latest_version_number(fw_signature)
     elif specified_fw_version == 'release':
-        specified_fw_version = get_released_fw_version(fw_signature, RELEASE_INFO)
+        specified_fw_version, _ = get_released_fw(fw_signature, RELEASE_INFO)
 
     if specified_fw_version is None:  # No latest.txt file
         die('Could not retrieve specified %s version in branch: %s' % (mode_name, branch_name))
@@ -283,7 +285,7 @@ def _update_all(force):
         slaveid, port, name, uart_settings = device_info.get_multiple_props('slaveid', 'port', 'name', 'uart_settings')
         modbus_connection = bindings.WBModbusDeviceBase(slaveid, port, *uart_settings)
         fw_signature = modbus_connection.get_fw_signature()
-        _latest_remote_version = get_released_fw_version(fw_signature, RELEASE_INFO) or downloader.get_latest_version_number(fw_signature)
+        _latest_remote_version, _ = get_released_fw(fw_signature, RELEASE_INFO) or downloader.get_latest_version_number(fw_signature)
         if _latest_remote_version is None:
             update_was_skipped.append(device_info)
             continue

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -4,11 +4,11 @@
 import logging
 import termios
 import json
+import yaml
 from json.decoder import JSONDecodeError
 import subprocess
 from pprint import pformat
 from distutils.version import LooseVersion
-from yaml import safe_load
 from . import fw_flasher, fw_downloader, user_log, jsondb, releases, die, PYTHON2, CONFIG
 
 import wb_modbus  # Setting up module's params
@@ -60,9 +60,9 @@ def get_released_fw(fw_signature, release_info):
     for url in releases.get_release_file_urls(release_info):  # repo-prefix is the first, if exists
         suite = release_info['SUITE']
         logging.debug("Looking to %s (suite: %s)" % (url, str(suite)))
-        contents = fw_downloader.get_releases_info(url)
+        contents = fw_downloader.get_release_versions(url)
         if contents:
-            fw_endpoint = safe_load(contents).get('releases', {}).get(fw_signature, {}).get(suite)
+            fw_endpoint = yaml.safe_load(contents).get('releases', {}).get(fw_signature, {}).get(suite)
             if fw_endpoint:
                 fw_version = releases.parse_fw_version(fw_endpoint)
                 logging.debug("FW version for %s on release %s: %s\nEndpoint: %s" % (fw_signature, suite, fw_version, fw_endpoint))

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import sys
 import logging
 import termios
 import json
@@ -9,6 +10,7 @@ from json.decoder import JSONDecodeError
 import subprocess
 from pprint import pformat
 from distutils.version import LooseVersion
+from posixpath import join as urljoin  # py2/3 compatibility
 from . import fw_flasher, fw_downloader, user_log, jsondb, releases, die, PYTHON2, CONFIG
 
 import wb_modbus  # Setting up module's params
@@ -48,6 +50,19 @@ def ask_user(message):
     return ret.upper().startswith('Y')
 
 
+def fill_release_info():  # TODO: make a class, storing a release-info context
+    """
+    wb-mcu-fw-updater supposed to be launched only on devices, supporting wb-releases
+    incorrect wb-releases file indicates strange erroneous behavior
+    """
+    releases_fname = CONFIG['RELEASES_FNAME']
+    try:
+        sys.modules[__name__].RELEASE_INFO = releases.parse_releases(releases_fname)  # instead of global
+    except Exception as e:
+        logging.error("Critical error in %s file!\nContact the support!" % releases_fname)
+        raise
+
+
 def get_released_fw(fw_signature, release_info):
     """
     Looking for released-fw:
@@ -76,9 +91,9 @@ def download_fw_fallback(fw_signature, release_info, ask_for_latest=True):
     _, released_fw_endpoint = get_released_fw(fw_signature, release_info)
 
     if released_fw_endpoint:
-        downloaded_fw = fw_downloader.download_file(fw_downloader.urljoin(CONFIG['ROOT_URL'], released_fw_endpoint))
+        downloaded_fw = fw_downloader.download_file(urljoin(CONFIG['ROOT_URL'], released_fw_endpoint))
     else:
-        logging.warning('Device "%s" is not supported in release "%s %s"' % (fw_signature, str(release_info.get('SUITE')), str(release_info.get('RELEASE_NAME'))))
+        logging.warning('Device "%s" is not supported in %s (as %s)' % (fw_signature, str(release_info.get('RELEASE_NAME')), str(release_info.get('SUITE'))))
         if (ask_for_latest) and (ask_user('Perform downloading from latest master anyway (may cause unstable behaviour; proceed at your own risk)?')):
             downloaded_fw = fw_downloader.RemoteFileWatcher('fw', branch_name='').download(fw_signature, 'latest')
     return downloaded_fw
@@ -359,7 +374,7 @@ def _update_all(force, allow_downgrade=False):  # TODO: maybe store fw endpoint 
             name, slaveid, port, mb_client, latest_remote_fw, fw_signature = device_info.get_multiple_props('name', 'slaveid', 'port', 'mb_client', 'latest_remote_fw', 'fw_signature')
             logging.info('Flashing firmware to %s' % str(device_info))
             _, released_fw_endpoint = get_released_fw(fw_signature, RELEASE_INFO)
-            downloaded_file = fw_downloader.download_file(fw_downloader.urljoin(CONFIG['ROOT_URL'], released_fw_endpoint))
+            downloaded_file = fw_downloader.download_file(urljoin(CONFIG['ROOT_URL'], released_fw_endpoint))
             try:
                 _do_flash(mb_client, downloaded_file, 'fw', False)
             except subprocess.CalledProcessError as e:


### PR DESCRIPTION
В упдатер приехали релизы. Поведение (копипаст из дев-чатика):
1) релизов нет (старый вб; нет /usr/lib/wb-release):
    - update-all не работает и предлагает или обновить контроллер, или обновить устройство руками (update-fw)
    - update-fw - старое поведение
    - recover - старое поведение
    - recover-all - старое поведение

2) релизы есть (новый вб):
   - update-fw смотрит в релизы и берет версию оттуда. Если для текущих suite/repo_prefix/fw_sig прошивки нет - спрашивает, скачать ли latest
   - update-fw --version берет версию, которую указали - полностью старое поведение
   - update-all смотрит только в релизы. Если прошивки для устройства нет - пропускает его обновление и ругается
   - recover смотрит в релизы. Если не нашел прошивку - спрашивает, скачать ли из stable/latest
   - recover-all смотрит только в релизы
   
Гонял упдатер во всех режимах для:

- вб без /usr/lib/wb-release
- вб с /usr/lib/wb-release (но для устройств не прописаны прошивки)
- прошивки указаны в релизе

релизный файлик использовал [этот](http://fw-releases.wirenboard.com/fw/by-signature/release-versions.git~feature~34944~firmware~releases~2104.yaml)