### PR TITLE
Bugfix/serial port settings

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.3.1) stable; urgency=medium
+
+  * wb_modbus.bindings: reworked serial port configuring (no annoying "Opening/closing port" messages anymore)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 26 May 2022 14:02:48 +0300
+
 wb-mcu-fw-updater (1.3.0) stable; urgency=medium
 
   * internal error-handling fixups

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ wb-mcu-fw-updater (1.3.1) stable; urgency=medium
 
   * wb_modbus.bindings: reworked serial port configuring (no annoying "Opening/closing port" messages anymore)
   * wb_modbus.bindings: applying settings to serial port before each communication
+  * wb_modbus.bindings: reworked @force decorator (could get number of tries from "retries" kw in func; more debug)
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 26 May 2022 14:02:48 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-mcu-fw-updater (1.3.1) stable; urgency=medium
 
   * wb_modbus.bindings: reworked serial port configuring (no annoying "Opening/closing port" messages anymore)
+  * wb_modbus.bindings: applying settings to serial port before each communication
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 26 May 2022 14:02:48 +0300
 

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -34,7 +34,7 @@ def force(retries=ALLOWED_UNSUCCESSFUL_TRIES):
     errtypes = (minimalmodbus.ModbusException, ValueError)
     def real_decorator(f):
         @wraps(f)
-        def wrapper(self, *args, **kwargs):
+        def wrapper(*args, **kwargs):
             tries = kwargs.pop('retries', retries)
             thrown_exc = None
             f_args = [repr(a) for a in args]
@@ -42,7 +42,7 @@ def force(retries=ALLOWED_UNSUCCESSFUL_TRIES):
             f_signature = "%s(%s)" % (f.__name__, ", ".join(f_args + f_kwargs))
             for i in range(tries):
                 try:
-                    return f(self, *args, **kwargs)
+                    return f(*args, **kwargs)
                 except errtypes as e:
                     thrown_exc = e
                     logger.debug("f = %s not succeed (try %d/%d)", f_signature, i + 1, tries)

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -17,6 +17,15 @@ class TooOldDeviceError(minimalmodbus.ModbusException):
 class UARTSettingsNotFoundError(Exception):
     pass
 
+def apply_serial_settings(f):
+    """
+    A decorator, applying actual settings to serial port before communication
+    """
+    @wraps(f)
+    def wrapper(self, *args, **kwargs):
+        self._set_port_settings_raw(self.settings)
+        return f(self, *args, **kwargs)
+    return wrapper
 
 def force(retries=ALLOWED_UNSUCCESSFUL_TRIES):
     """
@@ -28,13 +37,15 @@ def force(retries=ALLOWED_UNSUCCESSFUL_TRIES):
         def wrapper(self, *args, **kwargs):
             tries = kwargs.pop('retries', retries)
             thrown_exc = None
-            self._set_port_settings_raw(self.settings)
+            f_args = [repr(a) for a in args]
+            f_kwargs = ["%s=%s" % (k, repr(v)) for k, v in kwargs.items()]
+            f_signature = "%s(%s)" % (f.__name__, ", ".join(f_args + f_kwargs))
             for i in range(tries):
                 try:
                     return f(self, *args, **kwargs)
                 except errtypes as e:
                     thrown_exc = e
-                    logger.debug("%s not succeed (try %d/%d)", f.__name__, i + 1, tries)
+                    logger.debug("f = %s not succeed (try %d/%d)", f_signature, i + 1, tries)
             else:
                 if thrown_exc: #python3 wants exception to be defined already
                     raise thrown_exc
@@ -120,6 +131,7 @@ class MinimalModbusAPIWrapper(object):
         self._set_port_settings_raw(settings)
         logger.debug("Set %s to %s", str(self.settings), self.port)
 
+    @apply_serial_settings
     @force()
     def read_bit(self, addr):
         """
@@ -132,6 +144,7 @@ class MinimalModbusAPIWrapper(object):
         """
         return self.device.read_bit(addr, 2)
 
+    @apply_serial_settings
     @force()
     def write_bit(self, addr, value):
         """
@@ -144,6 +157,7 @@ class MinimalModbusAPIWrapper(object):
         """
         self.device.write_bit(addr, value, 5)
 
+    @apply_serial_settings
     @force()
     def read_bits(self, addr, length):
         """
@@ -158,6 +172,7 @@ class MinimalModbusAPIWrapper(object):
         """
         return self.device.read_bits(addr, length, 2)
 
+    @apply_serial_settings
     @force()
     def write_bits(self, addr, values_list):
         """
@@ -170,6 +185,7 @@ class MinimalModbusAPIWrapper(object):
         """
         self.device.write_bits(addr, values_list)
 
+    @apply_serial_settings
     @force()
     def read_u16(self, addr):
         """
@@ -182,6 +198,7 @@ class MinimalModbusAPIWrapper(object):
         """
         return self.device.read_register(addr, 0, 3, signed=False)
 
+    @apply_serial_settings
     @force()
     def read_s16(self, addr):
         """
@@ -194,6 +211,7 @@ class MinimalModbusAPIWrapper(object):
         """
         return self.device.read_register(addr, 0, 3, signed=True)
 
+    @apply_serial_settings
     @force()
     def write_u16(self, addr, value):
         """
@@ -206,6 +224,7 @@ class MinimalModbusAPIWrapper(object):
         """
         self.device.write_register(addr, value, 0, 6, signed=False)
 
+    @apply_serial_settings
     @force()
     def write_u16_regs(self, beginning, values):
         """
@@ -218,6 +237,7 @@ class MinimalModbusAPIWrapper(object):
         """
         self.device.write_registers(beginning, values)
 
+    @apply_serial_settings
     @force()
     def read_u16_holdings(self, beginning, number_of_regs):
         """
@@ -232,6 +252,7 @@ class MinimalModbusAPIWrapper(object):
         """
         return self.device.read_registers(beginning, number_of_regs, 3)
 
+    @apply_serial_settings
     @force()
     def read_u16_inputs(self, beginning, number_of_regs):
         """
@@ -246,6 +267,7 @@ class MinimalModbusAPIWrapper(object):
         """
         return self.device.read_registers(beginning, number_of_regs, 4)
 
+    @apply_serial_settings
     @force()
     def write_s16(self, addr, value):
         """
@@ -258,6 +280,7 @@ class MinimalModbusAPIWrapper(object):
         """
         self.device.write_register(addr, value, 0, 6, signed=True)
 
+    @apply_serial_settings
     @force()
     def read_u32_big_endian(self, addr, byteswap=False):
         """
@@ -276,6 +299,7 @@ class MinimalModbusAPIWrapper(object):
             order = minimalmodbus.BYTEORDER_BIG
         return self.device.read_long(addr, 3, signed=False, byteorder=order)
 
+    @apply_serial_settings
     @force()
     def read_u32_little_endian(self, addr, byteswap=False):
         """
@@ -294,6 +318,7 @@ class MinimalModbusAPIWrapper(object):
             order = minimalmodbus.BYTEORDER_LITTLE
         return self.device.read_long(addr, 3, signed=False, byteorder=order)
 
+    @apply_serial_settings
     @force()
     def read_s32_big_endian(self, addr, byteswap=False):
         """
@@ -312,6 +337,7 @@ class MinimalModbusAPIWrapper(object):
             order = minimalmodbus.BYTEORDER_BIG
         return self.device.read_long(addr, 3, signed=True, byteorder=order)
 
+    @apply_serial_settings
     @force()
     def read_s32_little_endian(self, addr, byteswap=False):
         """
@@ -330,6 +356,7 @@ class MinimalModbusAPIWrapper(object):
             order = minimalmodbus.BYTEORDER_LITTLE
         return self.device.read_long(addr, 3, signed=True, byteorder=order)
 
+    @apply_serial_settings
     @force()
     def write_u32_big_endian(self, addr, value, byteswap=False):
         """
@@ -348,6 +375,7 @@ class MinimalModbusAPIWrapper(object):
             order = minimalmodbus.BYTEORDER_BIG
         self.device.write_long(addr, value, signed=False, byteorder=order)
 
+    @apply_serial_settings
     @force()
     def write_u32_little_endian(self, addr, value, byteswap=False):
         """
@@ -366,6 +394,7 @@ class MinimalModbusAPIWrapper(object):
             order = minimalmodbus.BYTEORDER_LITTLE
         self.device.write_long(addr, value, signed=False, byteorder=order)
 
+    @apply_serial_settings
     @force()
     def write_s32_big_endian(self, addr, value, byteswap=False):
         """
@@ -384,6 +413,7 @@ class MinimalModbusAPIWrapper(object):
             order = minimalmodbus.BYTEORDER_BIG
         self.device.write_long(addr, value, signed=True, byteorder=order)
 
+    @apply_serial_settings
     @force()
     def write_s32_little_endian(self, addr, value, byteswap=False):
         """
@@ -402,6 +432,7 @@ class MinimalModbusAPIWrapper(object):
             order = minimalmodbus.BYTEORDER_LITTLE
         self.device.write_long(addr, value, signed=True, byteorder=order)
 
+    @apply_serial_settings
     @force()
     def read_string(self, addr, regs_lenght):
         """


### PR DESCRIPTION
@wb-adegtyarev заметил, что упдатер 1.3.0 обновляет только по одному устройству в чемодане

причина - в чемодане у устройств BD 115200 (видимо, я не проверил кейс, когда в сериале установлен нестандартный BD) => одно устройство прошивается, и порт остаётся c BD 9600 (после бутлоадера) => следующие устройства не могут перейти в бутлоадер

почему так получилось - в порции больших изменений инстансы Instrument'a (modbus_connection) стали ходить между функциями, а не создаваться каждый раз заново (а физически применение настроек порту дергается в ините Instrument'a) => всё работало по счастливому стечению обстоятельств

теперь применяем настройки к порту при каждом обращении к устройству