### PR TITLE
update_monitor: improved non-wb devices recognition

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.3.1) stable; urgency=medium
+
+  * improved non-wb devices recognition
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Fri, 27 May 2022 10:46:11 +0300
+
 wb-mcu-fw-updater (1.3.0) stable; urgency=medium
 
   * internal error-handling fixups

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -134,7 +134,7 @@ def get_correct_modbus_connection(slaveid, port, known_uart_params_str=None):  #
         fw_sig = modbus_connection.get_fw_signature()
     except bindings.TooOldDeviceError as e:
         fw_sig = ''
-    except ValueError as e:  # minimalmodbus's slaveid check performs at _exec_command stage
+    except (ValueError, minimalmodbus.SlaveReportedException) as e:  # minimalmodbus's slaveid check performs at _exec_command stage
         six.raise_from(ForeignDeviceError, e)
 
     try:  # WB devices assume to have all these regs


### PR DESCRIPTION
в теме 2 проблемы: эта и с настройками порта
PR конкретно к этому посту
https://support.wirenboard.com/t/wb-mcu-fw-updater-update-all-valitsya-posle-obnovleniya-pervogo-ustrojstva/11082/10