### PR TITLE
Feature/49836 cli improvements

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
 wb-mcu-fw-updater (1.5.0) stable; urgency=medium
 
   * update-fw/flash-file handle in-bootloader devices automatically
+  * update-all automatically flash in-bootloader devices
   * remove -j arg from flash-file
-  * --force arg removes all interactivity
+  * -f/--force arg removes all interactivity
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 11 Jul 2022 08:57:38 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+wb-mcu-fw-updater (1.5.0) stable; urgency=medium
+
+  * update-fw/flash-file handles in-bootloader devices automatically
+  * remove -j arg from flash-file
+  * --force arg removes all interactivity
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 11 Jul 2022 08:57:38 +0300
+
 wb-mcu-fw-updater (1.4.0) stable; urgency=medium
 
   * added stopbits-tolerant instrument (write - 2sb; read - 1sb; only for in-bootloader communications now)

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -20,23 +20,43 @@ def check_internet_connection():
 def _update_alive_device(slaveid, port, mode, response_timeout, branch, version, force, erase_settings):
     check_internet_connection()
 
-    try:
-        modbus_connection = update_monitor.get_correct_modbus_connection(slaveid, port, response_timeout=response_timeout)
-    except ModbusException as e:
-        logger.error("Check device's connection, slaveid and serial port settings!")
-        die(e)
+    device_str = "%s %d; response_timeout: %.2fs" % (port, slaveid, response_timeout)
+    modbus_connection = WBModbusDeviceBase(slaveid, port, response_timeout=response_timeout)
+
+    is_in_bootloader = modbus_connection.is_in_bootloader()  # 9600N2
+    if not is_in_bootloader:  # finding uart params
+        try:
+            conn_settings = update_monitor.find_connection_params(slaveid, port, response_timeout)
+            modbus_connection._set_port_settings_raw(conn_settings)
+        except ModbusException as e:
+            logger.error("Check (%s) physical connection, slaveid and serial port!", device_str)
+            die(e)
 
     try:
-        update_monitor.flash_alive_device(modbus_connection, mode, branch, version, force, erase_settings)
-        logger.info('%s', user_log.colorize('Done', 'GREEN'))
+        if is_in_bootloader:
+            logger.warning("Device (%s) supposed to be alive, but found in bootloader", device_str)
+            logger.debug("Trying to acquire fw-signature...")
+            fw_sig = update_monitor._restore_fw_signature(slaveid, port, response_timeout)
+            if fw_sig:
+                logger.info("Will flash latest released FW to bring %s (%s) alive", fw_sig, device_str)
+                update_monitor.recover_device_iteration(fw_sig, slaveid, port, response_timeout)
+            else:
+                logger.error("Could not find fw-signature for (%s)", device_str)
+                logger.error('Try to launch "recover" mode with --fw-sig provided manually')
+                die()
+        else:  # device is alive
+            update_monitor.check_device_is_a_wb_one(modbus_connection)
+            update_monitor.flash_alive_device(modbus_connection, mode, branch, version, force, erase_settings)
+            logger.info('%s', user_log.colorize('Done', 'GREEN'))
     except (
         TooOldDeviceError,
         ModbusException,
         update_monitor.UpdateDeviceError,
         update_monitor.NoReleasedFwError,
+        update_monitor.ForeignDeviceError,
         fw_downloader.WBRemoteStorageError,
         fw_flasher.FlashingError ) as e:
-        logger.error("Flashing %s to (%d %s) has failed!", mode, slaveid, port)
+        logger.error("Flashing %s to (%s) has failed!", mode, device_str)
         die(e)
 
 

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -127,12 +127,13 @@ def flash_fw_file(args):
     """
     Directly flashing a fw-file (passed as arg) (args are almost compatible to wb-mcu-fw-flasher)
     """
-    device_str = "%s %d %s" % (args.port, args.slaveid, str(args.conn_settings))
-
-    if args.jump_in_bl:
-        _device = WBModbusDeviceBase(args.slaveid, args.port, *args.conn_settings, response_timeout=args.response_timeout)
+    device_str = "%s %d %s (response timeout: %.2f)" % (
+                                args.port, args.slaveid, str(args.conn_settings), args.response_timeout)
+    device = WBModbusDeviceBase(args.slaveid, args.port, *args.conn_settings, response_timeout=args.response_timeout)
+    if not device.is_in_bootloader():
+        logger.debug("Rebooting %s to bootloader", device_str)
         try:
-            _device.reboot_to_bootloader()
+            device.reboot_to_bootloader()
         except ModbusException as e:
             die("Device (%s) could not reboot to bootloader. Check connection params" % device_str)
 
@@ -140,8 +141,7 @@ def flash_fw_file(args):
         update_monitor.direct_flash(args.fname, args.slaveid, args.port, args.response_timeout, args.erase_all, args.erase_uart)
         return
     except fw_flasher.NotInBootloaderError as e:
-        logger.error("Seems, device (%s) is not in bootloader now!", device_str)
-        logger.error("Try again with '-j' arg")
+        logger.error("Seems, device (%s) is not in bootloader mode", device_str)
     except (fw_flasher.FlashingError, update_monitor.UserCancelledError) as e:
         logger.exception(e)
     logger.error("Unsuccessful flashing!")
@@ -240,8 +240,6 @@ def parse_args():
     direct_flash_parser.add_argument('--conn-settings', type=parse_conn_settings_arg, dest='conn_settings',
                                 metavar='<connection_settings_str>', default='9600N2',
                                 help="Connection settings to communicate with alive device (Default: %(default)s)")
-    direct_flash_parser.add_argument('-j', action='store_true', dest='jump_in_bl', default=False,
-                                help='Jump to bootloader? (use on alive devices; default: %(default)s)')
     direct_flash_parser.add_argument('-u', '--erase-uart', action='store_true', dest='erase_uart',
                                 default=False, help="Erase device's uart settings? (Default: %(default)s)")
     direct_flash_parser.add_argument('-e', '--erase-all', action='store_true', dest='erase_all',

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -20,7 +20,7 @@ def check_internet_connection():
 def _update_alive_device(slaveid, port, mode, response_timeout, branch, version, force, erase_settings):
     check_internet_connection()
 
-    device_str = "%s %d; response_timeout: %.2fs" % (port, slaveid, response_timeout)
+    device_str = "(%s %d; response_timeout: %.2fs)" % (port, slaveid, response_timeout)
     modbus_connection = WBModbusDeviceBase(slaveid, port, response_timeout=response_timeout)
 
     is_in_bootloader = modbus_connection.is_in_bootloader()  # 9600N2
@@ -29,19 +29,19 @@ def _update_alive_device(slaveid, port, mode, response_timeout, branch, version,
             conn_settings = update_monitor.find_connection_params(slaveid, port, response_timeout)
             modbus_connection._set_port_settings_raw(conn_settings)
         except ModbusException as e:
-            logger.error("Check (%s) physical connection, slaveid and serial port!", device_str)
+            logger.error("Can't connect to %s, check physical connection or address/port", device_str)
             die(e)
 
     try:
         if is_in_bootloader:
-            logger.warning("Device (%s) supposed to be alive, but found in bootloader", device_str)
+            logger.info("Device %s supposed to be alive, but found in bootloader", device_str)
             logger.debug("Trying to acquire fw-signature...")
             fw_sig = update_monitor._restore_fw_signature(slaveid, port, response_timeout)
             if fw_sig:
-                logger.info("Will flash latest released FW to bring %s (%s) alive", fw_sig, device_str)
+                logger.info("Will flash latest released FW to bring %s %s alive", fw_sig, device_str)
                 update_monitor.recover_device_iteration(fw_sig, slaveid, port, response_timeout)
             else:
-                logger.error("Could not find fw-signature for (%s)", device_str)
+                logger.error("Could not find fw-signature for %s", device_str)
                 logger.error('Try to launch "recover" mode with --fw-sig provided manually')
                 die()
         else:  # device is alive
@@ -56,7 +56,7 @@ def _update_alive_device(slaveid, port, mode, response_timeout, branch, version,
         update_monitor.ForeignDeviceError,
         fw_downloader.WBRemoteStorageError,
         fw_flasher.FlashingError ) as e:
-        logger.error("Flashing %s to (%s) has failed!", mode, device_str)
+        logger.error("Flashing %s to %s has failed!", mode, device_str)
         die(e)
 
 

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -157,114 +157,99 @@ def parse_conn_settings_arg(conn_settings_str):
         die()
 
 
+def add_common_logic_args(parser):
+    parser.add_argument('--force', action='store_true', dest='force', default=False,
+                                help='Perform force device reflash, even if firmware is latest. (Default: %(default)s)')
+    parser.add_argument('--debug', dest='user_loglevel', default=None, action='store_const',
+                                const=10, help='Setting the least loglevel. (Default: %(default)s)')
+
+
+def add_modbus_connection_args(parser):
+    parser.add_argument('-T', '--response-timeout', type=float, dest='response_timeout',
+                                metavar='<response_timeout>', default=0.2,
+                                help='Modbus response timeout. (Default: %(default)s)')
+    parser.add_argument('-a', '--slaveid', type=int, dest='slaveid', metavar='<slaveid>',
+                                required=True, choices=range(1, 247), help='Slave address of the device.')
+    parser.add_argument("port", type=str, metavar='<port>', help='Serial port, device connected to.')
+
+
+def add_fw_source_args(parser):
+    parser.add_argument('--branch', type=str, dest='branch_name', metavar='<branch_name>', default='',
+                                help='Install firmware from specified branch. (Default: %(default)s)')
+    parser.add_argument('--version', type=str, dest='specified_version', metavar='<fw_version>',
+                                default='release', help='Download a specified firmware version. (Default: %(default)s)')
+
+
 def parse_args():
     main_parser = argparse.ArgumentParser(prog='wb-mcu-fw-updater', formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-                                          description='Wiren Board modbus devices firmware/bootloader update tool.', add_help=True)
-    main_parser.add_argument('--debug', dest='user_loglevel', default=None, action='store_const',
-                             const=10, help='Setting the least loglevel. (Default: %(default)s)')
-    subparsers = main_parser.add_subparsers(
-        title='Actions', help='Choose mode:\n')
+                                description='Wiren Board modbus devices firmware/bootloader update tool.', add_help=True)
+    subparsers = main_parser.add_subparsers(title='Actions', help='Choose mode:\n')
 
-    """
-    Updating firmware on single working device.
-    """
-    update_fw_parser = subparsers.add_parser(
-        'update-fw', help='Update firmware on single working device.')
-    update_fw_parser.add_argument('--branch', type=str, dest='branch_name', metavar='<branch_name>', default='',
-                                  help='Install firmware from specified branch. (Default: %(default)s)')
-    update_fw_parser.add_argument('--version', type=str, dest='specified_version', metavar='<fw_version>',
-                                  default='release', help='Download a specified firmware version. (Default: %(default)s)')
+    #Updating firmware on single working device
+    update_fw_parser = subparsers.add_parser('update-fw', help='Update firmware on single working device.')
     update_fw_parser.add_argument('--restore-defaults', action='store_true', dest='erase_settings',
-                                  default=False, help="Erase all device's settings during update. (Default: %(default)s)")
-    update_fw_parser.add_argument('-f', '--force', action='store_true', dest='force', default=False,
-                                  help='Perform force device reflash, even if firmware is latest. (Default: %(default)s)')
-    update_fw_parser.add_argument('-T', '--response-timeout', type=float, dest='response_timeout', metavar='<response_timeout>', default=0.2,
-                                  help='Modbus response timeout. (Default: %(default)s)')
-    update_fw_parser.add_argument(
-        '-a', '--slaveid', type=int, dest='slaveid', metavar='<slaveid>', required=True, choices=range(1, 247), help='Slave address of the device.')
-    update_fw_parser.add_argument(
-        "port", type=str, metavar='<port>', help='Serial port, device connected to.')
+                                default=False, help="Erase all device's settings during update. (Default: %(default)s)")
+    add_common_logic_args(update_fw_parser)
+    add_modbus_connection_args(update_fw_parser)
+    add_fw_source_args(update_fw_parser)
     update_fw_parser.set_defaults(func=update_fw)
 
-    """
-    Updating bootloader on single working device.
-    """
-    update_bootloader_parser = subparsers.add_parser(
-        'update-bl', help='Update bootloader on single working device.')
-    update_bootloader_parser.add_argument('-f', '--force', action='store_true', dest='force', default=False,
-                                          help='Perform force device reflash, even if firmware is latest. (Default: %(default)s)')
-    update_bootloader_parser.add_argument(
-        '-a', '--slaveid', type=int, metavar='<slaveid>', dest='slaveid', required=True, choices=range(1, 247), help='Slave address of the device.')
-    update_bootloader_parser.add_argument(
-        '-T', '--response-timeout', type=float, dest='response_timeout', metavar='<response_timeout>', default=0.2,
-        help='Modbus response timeout. (Default: %(default)s)')
-    update_bootloader_parser.add_argument(
-        "port", type=str, metavar='<port>', help='Serial port, device connected to.')
+    #Updating bootloader on single working device
+    update_bootloader_parser = subparsers.add_parser('update-bl', help='Update bootloader on single working device.')
+    add_common_logic_args(update_bootloader_parser)
+    add_modbus_connection_args(update_bootloader_parser)
     update_bootloader_parser.set_defaults(func=update_bootloader)
 
-    """
-    Flash single device, stuck in the bootloader.
-    """
-    recover_fw_parser = subparsers.add_parser(
-        'recover', help="Restore the latest firmware on stuck in bootloader device.")
+    #Flash single device, stuck in the bootloader
+    recover_fw_parser = subparsers.add_parser('recover',
+                                help="Restore the latest firmware on stuck in bootloader device.")
     recover_fw_parser.add_argument('--fw-sig', dest='known_signature', type=str, metavar='<fw_signature>', default=None,
-                                   help="Force specify device's firmware signature. (Default: %(default)s)")
+                                help="Force specify device's firmware signature. (Default: %(default)s)")
     recover_fw_parser.add_argument('--restore-defaults', action='store_true', dest='erase_settings',
-                                   default=False, help="Erase all device's settings during flashing. (Default: %(default)s)")
-    recover_fw_parser.add_argument('-T', '--response-timeout', type=float, dest='response_timeout', metavar='<response_timeout>', default=0.2,
-                                  help="Modbus response timeout. (Default: %(default)s)")
-    recover_fw_parser.add_argument(
-        '-a', '--slaveid', type=int, dest='slaveid', metavar='<slaveid>', required=True, help='Slave address of the device.')
-    recover_fw_parser.add_argument(
-        "port", type=str, metavar='<port>', help='Serial port, device connected to.')
+                                default=False, help="Erase all device's settings during flashing. (Default: %(default)s)")
+    add_common_logic_args(recover_fw_parser)
+    add_modbus_connection_args(recover_fw_parser)
     recover_fw_parser.set_defaults(func=recover_fw)
 
-    """
-    Update firmware on all devices, found in wb-mqtt-serial config.
-    """
-    update_all_fw_parser = subparsers.add_parser(
-        'update-all', help="Trying to update firmwares on all devices, added to wb-mqtt-serial's config.")
-    update_all_fw_parser.add_argument('-f', '--force', action='store_true', dest='force', default=False,
-                                    help='Perform force updates of all devices, even if firmwares are latest. (Default: %(default)s)')
+    #Update firmware on all devices, found in wb-mqtt-serial config
+    update_all_fw_parser = subparsers.add_parser('update-all',
+                                help="Trying to update firmwares on all devices, added to wb-mqtt-serial's config.")
     update_all_fw_parser.add_argument('--allow-downgrade', action='store_true', dest='allow_downgrade', default=False,
-                                    help='Firmware versions could be downgraded. (Default: %(default)s)')
-    update_all_fw_parser.add_argument(
-        '-T', '--min-response-timeout', type=float, dest='minimal_response_timeout', metavar='<minimal_response_timeout>', default=0.5,
-        help="Minimal modbus response timeout. Actual response timeout is: MAX(min_response_timeout, wb-mqtt-serial's response timeouts) (Default: %(default)s)")
+                                help='Firmware versions could be downgraded. (Default: %(default)s)')
+    update_all_fw_parser.add_argument('-T', '--min-response-timeout', type=float, dest='minimal_response_timeout',
+                                metavar='<minimal_response_timeout>', default=0.5,
+                                help="""Minimal modbus response timeout. Actual response timeout is: \
+                                MAX(min_response_timeout, wb-mqtt-serial's response timeouts) \
+                                (Default: %(default)s)""")
+    add_common_logic_args(update_all_fw_parser)
     update_all_fw_parser.set_defaults(func=update_all)
 
-    """
-    Recover firmware on all devices, found in wb-mqtt-serial config (and are actually in bootloader).
-    """
-    recover_all_parser = subparsers.add_parser(
-        'recover-all', help="Trying to recover all devices, added to wb-mqtt-serial's config.")
-    recover_all_parser.add_argument(
-        '-T', '--min-response-timeout', type=float, dest='minimal_response_timeout', metavar='<minimal_response_timeout>', default=0.5,
-        help="Minimal modbus response timeout. Actual response timeout is: MAX(min_response_timeout, wb-mqtt-serial's response timeouts) (Default: %(default)s)")
+    #Recover firmware on all devices, found in wb-mqtt-serial config (and are actually in bootloader)
+    recover_all_parser = subparsers.add_parser('recover-all',
+                                help="Trying to recover all devices, added to wb-mqtt-serial's config.")
+    recover_all_parser.add_argument('-T', '--min-response-timeout', type=float, dest='minimal_response_timeout',
+                                metavar='<minimal_response_timeout>', default=0.5,
+                                help="""Minimal modbus response timeout. Actual response timeout is: \
+                                MAX(min_response_timeout, wb-mqtt-serial's response timeouts) \
+                                (Default: %(default)s)""")
+    add_common_logic_args(recover_all_parser)
     recover_all_parser.set_defaults(func=recover_all)
 
-    """
-    Flash a FW file to single device.
-    """
-    direct_flash_parser = subparsers.add_parser(
-        'flash-file', help="Directly flash firmware file")
-    direct_flash_parser.add_argument(
-        "port", type=str, metavar='<serial_port>')
-    direct_flash_parser.add_argument(
-        '-a', '--slaveid', type=int, dest='slaveid', metavar='<slaveid>', required=True, help='Slave address of the device')
-    direct_flash_parser.add_argument(
-        '-T', '--response-timeout', type=float, dest='response_timeout', metavar='<response_timeout>', default=0.5,
-        help='Modbus response timeout. (Default: %(default)s)')
-    direct_flash_parser.add_argument(
-        '--conn-settings', type=parse_conn_settings_arg, dest='conn_settings', metavar='<connection_settings_str>', default='9600N2', help="Connection settings to communicate with alive device (Default: %(default)s)")
-    direct_flash_parser.add_argument(
-        '-j', action='store_true', dest='jump_in_bl', default=False, help='Jump to bootloader? (use on alive devices; default: %(default)s)')
-    direct_flash_parser.add_argument(
-        '-u', '--erase-uart', action='store_true', dest='erase_uart', default=False, help="Erase device's uart settings? (Default: %(default)s)")
-    direct_flash_parser.add_argument(
-        '-e', '--erase-all', action='store_true', dest='erase_all', default=False, help="Erase ALL device's uart settings? (Default: %(default)s)")
-    direct_flash_parser.add_argument(
-        '-f', type=str, dest='fname', metavar='<firmware_file>', required=True, help='File to flash')
+    #Flash a FW file to single device.
+    direct_flash_parser = subparsers.add_parser('flash-file', help="Directly flash firmware file")
+    direct_flash_parser.add_argument('--conn-settings', type=parse_conn_settings_arg, dest='conn_settings',
+                                metavar='<connection_settings_str>', default='9600N2',
+                                help="Connection settings to communicate with alive device (Default: %(default)s)")
+    direct_flash_parser.add_argument('-j', action='store_true', dest='jump_in_bl', default=False,
+                                help='Jump to bootloader? (use on alive devices; default: %(default)s)')
+    direct_flash_parser.add_argument('-u', '--erase-uart', action='store_true', dest='erase_uart',
+                                default=False, help="Erase device's uart settings? (Default: %(default)s)")
+    direct_flash_parser.add_argument('-e', '--erase-all', action='store_true', dest='erase_all',
+                                default=False, help="Erase ALL device's uart settings? (Default: %(default)s)")
+    direct_flash_parser.add_argument('-f', type=str, dest='fname', metavar='<firmware_file>',
+                                required=True, help='File to flash')
+    add_common_logic_args(direct_flash_parser)
+    add_modbus_connection_args(direct_flash_parser)
     direct_flash_parser.set_defaults(func=flash_fw_file)
 
     args = main_parser.parse_args()

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -38,8 +38,14 @@ def _update_alive_device(slaveid, port, mode, response_timeout, branch, version,
             logger.debug("Trying to acquire fw-signature...")
             fw_sig = update_monitor._restore_fw_signature(slaveid, port, response_timeout)
             if fw_sig:
-                logger.info("Will flash latest released FW to bring %s %s alive", fw_sig, device_str)
-                update_monitor.recover_device_iteration(fw_sig, slaveid, port, response_timeout)
+                downloaded_fw, fw_version = update_monitor._do_download(fw_sig, version, branch, mode,
+                    retrieve_latest_vnum=False)
+                logger.info("Will flash %s v_%s to bring %s %s alive", mode, fw_version, fw_sig, device_str)
+                update_monitor.direct_flash(downloaded_fw, modbus_connection.slaveid, modbus_connection.port,
+                    response_timeout, erase_all_settings=erase_settings, force=force)
+                if mode == "bootloader":  # we don't know fw's branch/version (only bl's ones)
+                    update_monitor.recover_device_iteration(fw_sig, modbus_connection.slaveid,
+                        modbus_connection.port, response_timeout, force)
             else:
                 logger.error("Could not find fw-signature for %s", device_str)
                 logger.error('Try to launch "recover" mode with --fw-sig provided manually')

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -62,16 +62,16 @@ def _update_alive_device(slaveid, port, mode, response_timeout, branch, version,
 
 def update_fw(args):
     # Could install specified fw_version from specified branch.
-    version = args.version or "release"
+    version = args.specified_version or "release"
     _update_alive_device(slaveid=args.slaveid, port=args.port, mode='fw', response_timeout=args.response_timeout,
         branch=args.branch_name, version=version, force=args.force, erase_settings=args.erase_settings)
 
 
 def update_bootloader(args):
     # Could install specified bl_version from specified branch.
-    version = args.version or "latest"  # no bl-releases.yaml yet
+    version = args.specified_version or "latest"  # no bl-releases.yaml yet
     _update_alive_device(slaveid=args.slaveid, port=args.port, mode='bootloader', response_timeout=args.response_timeout,
-        branch=args.branch_name, version=args.specified_version, force=args.force, erase_settings=False)
+        branch=args.branch_name, version=version, force=args.force, erase_settings=False)
 
 
 def recover_fw(args):
@@ -136,7 +136,7 @@ def recover_all(args):
     """
     check_internet_connection()
     try:
-        update_monitor._recover_all(minimal_response_timeout=args.minimal_response_timeout)
+        update_monitor._recover_all(minimal_response_timeout=args.minimal_response_timeout, force=args.force)
     except update_monitor.ConfigParsingError as e:
         die(e)
 

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -182,7 +182,7 @@ def parse_conn_settings_arg(conn_settings_str):
 
 
 def add_common_logic_args(parser):
-    parser.add_argument('--force', action='store_true', dest='force', default=False,
+    parser.add_argument('-f', '--force', action='store_true', dest='force', default=False,
                                 help='Perform force device reflash, even if firmware is latest. (Default: %(default)s)')
     parser.add_argument('--debug', dest='user_loglevel', default=None, action='store_const',
                                 const=10, help='Setting the least loglevel. (Default: %(default)s)')
@@ -269,7 +269,7 @@ def parse_args():
                                 default=False, help="Erase device's uart settings? (Default: %(default)s)")
     direct_flash_parser.add_argument('-e', '--erase-all', action='store_true', dest='erase_all',
                                 default=False, help="Erase ALL device's uart settings? (Default: %(default)s)")
-    direct_flash_parser.add_argument('-f', type=str, dest='fname', metavar='<firmware_file>',
+    direct_flash_parser.add_argument('--file', type=str, dest='fname', metavar='<firmware_file>',
                                 required=True, help='File to flash')
     add_common_logic_args(direct_flash_parser)
     add_modbus_connection_args(direct_flash_parser)

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -61,19 +61,17 @@ def _update_alive_device(slaveid, port, mode, response_timeout, branch, version,
 
 
 def update_fw(args):
-    """
-    Updating device's firmware.
-    Could install specified fw_version from specified branch.
-    """
-    _update_alive_device(slaveid=args.slaveid, port=args.port, mode='fw', response_timeout=args.response_timeout, branch=args.branch_name, version=args.specified_version, force=args.force, erase_settings=args.erase_settings)
+    # Could install specified fw_version from specified branch.
+    version = args.version or "release"
+    _update_alive_device(slaveid=args.slaveid, port=args.port, mode='fw', response_timeout=args.response_timeout,
+        branch=args.branch_name, version=version, force=args.force, erase_settings=args.erase_settings)
 
 
 def update_bootloader(args):
-    """
-    Updating device's bootloader.
-    Only latest version from stable branch is available.
-    """
-    _update_alive_device(slaveid=args.slaveid, port=args.port, mode='bootloader', response_timeout=args.response_timeout, branch='', version='latest', force=args.force, erase_settings=False)
+    # Could install specified bl_version from specified branch.
+    version = args.version or "latest"  # no bl-releases.yaml yet
+    _update_alive_device(slaveid=args.slaveid, port=args.port, mode='bootloader', response_timeout=args.response_timeout,
+        branch=args.branch_name, version=args.specified_version, force=args.force, erase_settings=False)
 
 
 def recover_fw(args):
@@ -195,9 +193,9 @@ def add_modbus_connection_args(parser):
 
 def add_fw_source_args(parser):
     parser.add_argument('--branch', type=str, dest='branch_name', metavar='<branch_name>', default='',
-                                help='Install firmware from specified branch. (Default: %(default)s)')
+                                help='Install from specified branch. (Default: %(default)s)')
     parser.add_argument('--version', type=str, dest='specified_version', metavar='<fw_version>',
-                                default='release', help='Download a specified firmware version. (Default: %(default)s)')
+                                default=None, help='Download a specified version. (Default: %(default)s)')
 
 
 def parse_args():
@@ -218,6 +216,7 @@ def parse_args():
     update_bootloader_parser = subparsers.add_parser('update-bl', help='Update bootloader on single working device.')
     add_common_logic_args(update_bootloader_parser)
     add_modbus_connection_args(update_bootloader_parser)
+    add_fw_source_args(update_bootloader_parser)
     update_bootloader_parser.set_defaults(func=update_bootloader)
 
     #Flash single device, stuck in the bootloader

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -39,8 +39,8 @@ def _update_alive_device(slaveid, port, mode, response_timeout, branch, version,
             fw_sig = update_monitor._restore_fw_signature(slaveid, port, response_timeout)
             if fw_sig:
                 downloaded_fw, fw_version = update_monitor._do_download(fw_sig, version, branch, mode,
-                    retrieve_latest_vnum=False)
-                logger.info("Will flash %s v_%s to bring %s %s alive", mode, fw_version, fw_sig, device_str)
+                    retrieve_latest_vnum=False)  # we don't need any update-check here
+                logger.info("Will flash %s v:%s to bring %s %s alive", mode, fw_version, fw_sig, device_str)
                 update_monitor.direct_flash(downloaded_fw, modbus_connection.slaveid, modbus_connection.port,
                     response_timeout, erase_all_settings=erase_settings, force=force)
                 if mode == "bootloader":  # we don't know fw's branch/version (only bl's ones)

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -342,8 +342,6 @@ def flash_alive_device(modbus_connection, mode, branch_name, specified_fw_versio
 
     device_str = "(%s %d on %s)" % (fw_signature, modbus_connection.slaveid, modbus_connection.port)
 
-    downloaded_fw, specified_fw_version = _do_download(fw_signature, specified_fw_version, branch_name, mode)
-
     """
     Flashing specified fw version (without any update-checking), if branch is unstable
     """
@@ -354,6 +352,8 @@ def flash_alive_device(modbus_connection, mode, branch_name, specified_fw_versio
             branch_name,
             specified_fw_version), force_yes=force
         ):
+            downloaded_fw, _ = _do_download(fw_signature, specified_fw_version, branch_name, mode,
+                retrieve_latest_vnum=False)  # TODO: fix latest.txt for bl branches on ci
             _do_flash(modbus_connection, downloaded_fw, mode, erase_settings, force=force)
             return
         else:
@@ -363,6 +363,7 @@ def flash_alive_device(modbus_connection, mode, branch_name, specified_fw_versio
     Reflashing with update-checking
     """
     device_fw_version = modbus_connection.get_bootloader_version() if mode == 'bootloader' else modbus_connection.get_fw_version()
+    downloaded_fw, specified_fw_version = _do_download(fw_signature, specified_fw_version, branch_name, mode)
 
     logger.info("%s %s:", mode, device_str)
     if is_reflash_necessary(

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -97,11 +97,12 @@ def get_released_fw(fw_signature, release_info):
                 logger.debug("FW version for %s on release %s: %s (endpoint: %s)", fw_signature, suite, fw_version, fw_endpoint)
                 return str(fw_version), str(fw_endpoint)
         except fw_downloader.RemoteFileReadingError as e:
-            logger.warning("No released fw for %s in %s", fw_signature, url)
+            logger.warning('No released fw for "%s" in "%s"', fw_signature, url)
         except releases.VersionParsingError as e:
             logger.exception(e)
     else:
-        raise NoReleasedFwError("Released FW not found for %s\nRelease info:\n%s" % (fw_signature, str(release_info)))
+        raise NoReleasedFwError('Released FW not found for "%s"\nRelease info:\n%s' %
+            (fw_signature, json.dumps(release_info, indent=4)))
 
 
 def download_fw_fallback(fw_signature, release_info, ask_for_latest=True, force=False):
@@ -480,7 +481,7 @@ def _update_all(force, minimal_response_timeout, allow_downgrade=False):  # TODO
             additional_info='You may try to run with "--force" or "--allow-downgrade" arg')
 
     if cmd_status['no_fw_release']:
-        print_status(logging.WARNING, status="Not supported in current (%s) release:" % str(RELEASE_INFO),
+        print_status(logging.WARNING, status="Not supported in current %s release:" % RELEASE_INFO.get("RELEASE_NAME", ""),
             devices_list=cmd_status['no_fw_release'], additional_info="You may try to switch to newer release")
 
     if probing_result['disconnected']:

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -285,7 +285,7 @@ def is_reflash_necessary(actual_version, provided_version, force_reflash=False, 
 
 def _do_download(fw_sig, version, branch, mode, retrieve_latest_vnum=True):
     """
-    Generic .wbfw downloading logic:
+    Generic .wbfw downloading logic: ("release" is a default val for version)
         version=="release"; branch==None -> looking into release-versions.yaml (default case)
         version=="release"; branch==<specified_branch> -> looking into branch/latest
         version==<specified_version>; branch==None -> looking into main/version
@@ -311,7 +311,7 @@ def _do_download(fw_sig, version, branch, mode, retrieve_latest_vnum=True):
     else:
         logger.debug("%s version has specified manually: %s", mode_name, version)
 
-    if version == "latest" and retrieve_latest_vnum:  # TODO: put unstable_bl version to latest.txt on ci; then remove
+    if version == "latest" and retrieve_latest_vnum:  # TODO: put unstable_bl version to latest.txt on ci; then remove (task 51352)
         logger.debug("Retrieving latest %s version number for %s", mode_name, fw_sig)
         version = downloader.get_latest_version_number(fw_sig)  # to guess, is reflash needed or not
 
@@ -354,7 +354,7 @@ def flash_alive_device(modbus_connection, mode, branch_name, specified_fw_versio
             specified_fw_version), force_yes=force
         ):
             downloaded_fw, _ = _do_download(fw_signature, specified_fw_version, branch_name, mode,
-                retrieve_latest_vnum=False)  # TODO: fix latest.txt for bl branches on ci
+                retrieve_latest_vnum=False)  # TODO: fix latest.txt for bl branches on ci (task 51352)
             _do_flash(modbus_connection, downloaded_fw, mode, erase_settings, force=force)
             return
         else:


### PR DESCRIPTION
- update-fw сам смотрит, в бутлоадере девайс или нет. Оживляет в любом случае. Если в бутлоадере и fw-sig достать не можем - предлагаем "recover"
- flash-file теперь не надо указывать -j (перезагрузку в бутлоадер) - разбирается сам
- --force убирает любую интерактивность
- --update-bl теперь ест branch и version

Несделанные хотелки:

- печатать версию упдатера при запуске. Версия встраивается ручками и довольно костыльно (а хочется - чтобы подтягивалась из дебианизации) => думаю, пока не надо
- показывать версии прошивок всех устройств в конфиге serial. Надо довольно глубоко копать; связанно с фичей по проверке обновлений; предлагаю сделать в её рамках