### PR TITLE
Feature/new eeprom map sn

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.4.1) stable; urgency=medium
+
+  * wb_modbus.bindings:_get_serial_number_map() gets 25 bits instead of 24
+
+ -- Narek Kazaryan <d.kazaryan@wirenboard.ru>  Thu, 14 Jul 2022 14:48:32 +0300
+
 wb-mcu-fw-updater (1.4.0) stable; urgency=medium
 
   * added stopbits-tolerant instrument (write - 2sb; read - 1sb; only for in-bootloader communications now)

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -554,7 +554,7 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
 
     def _get_serial_number_map(self):
         int_values = self.read_u16_inputs(self.COMMON_REGS_MAP['serial_number'], 2)
-        return ((int_values[0] % 256) * 65536) + int_values[1]
+        return int_values[0] << 16 + int_values[1] - 0xFE000000
 
     def get_fw_version(self):
         return self.read_string(self.COMMON_REGS_MAP['fw_version'], self.FIRMWARE_VERSION_LENGTH)

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -554,7 +554,7 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
 
     def _get_serial_number_map(self):
         int_values = self.read_u16_inputs(self.COMMON_REGS_MAP['serial_number'], 2)
-        return int_values[0] << 16 + int_values[1] - 0xFE000000
+        return int_values[0]*65536  + int_values[1] - 0xFE000000
 
     def get_fw_version(self):
         return self.read_string(self.COMMON_REGS_MAP['fw_version'], self.FIRMWARE_VERSION_LENGTH)


### PR DESCRIPTION
Для работы с новыми еепром, у мап теперь считывается не 24 бита, а 25