### PR TITLE
wb_modbus.bindings: handle decode error, when reading from modbus regs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.5.1) stable; urgency=medium
+
+  * wb_modbus.bindings: handle decode error, when reading from modbus regs
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 1 Aug 2022 11:01:41 +0300
+
 wb-mcu-fw-updater (1.5.0) stable; urgency=medium
 
   * update-fw/flash-file handle in-bootloader devices automatically

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 wb-mcu-fw-updater (1.5.1) stable; urgency=medium
 
-  * wb_modbus.bindings: handle decode error, when reading from modbus regs
+  * wb_modbus.bindings: fix failing on decode error, when reading from modbus regs
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 1 Aug 2022 11:01:41 +0300
 

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -450,11 +450,7 @@ class MinimalModbusAPIWrapper(object):
         ret = minimalmodbus._hexlify(self.device.read_string(addr, regs_lenght, 3))
         for placeholder in empty_chars_placeholders:  # Clearing a string to only meaningful bytes
             ret = ret.replace(placeholder, '')  # 'A1B2C3' bytes-only string
-        try:
-            return str(unhexlify(ret).decode('utf-8')).strip()
-        except UnicodeDecodeError as e:
-            logger.exception(e)
-            return ''
+        return str(unhexlify(ret).decode(encoding='utf-8', errors='ignore')).strip()  # TODO: "backslashreplace" when drop py2
 
 
 def auto_find_uart_settings(method_to_decorate):

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -450,7 +450,11 @@ class MinimalModbusAPIWrapper(object):
         ret = minimalmodbus._hexlify(self.device.read_string(addr, regs_lenght, 3))
         for placeholder in empty_chars_placeholders:  # Clearing a string to only meaningful bytes
             ret = ret.replace(placeholder, '')  # 'A1B2C3' bytes-only string
-        return str(unhexlify(ret).decode('utf-8')).strip()
+        try:
+            return str(unhexlify(ret).decode('utf-8')).strip()
+        except UnicodeDecodeError as e:
+            logger.exception(e)
+            return ''
 
 
 def auto_find_uart_settings(method_to_decorate):


### PR DESCRIPTION
контекст: updater подавился свистком u-cr. После рисёча/разбирательств, выяснилось, что в device_signature у u-cr случайно попали русские символы, а updater не ожидал такого.

решение - updater ожидает; device_signature поправили в прошивке (и выкатили уже давно)