### PR TITLE
Feature/54078 serial rpc

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ wb-mcu-fw-updater (1.6.0) stable; urgency=medium
   * wb_modbus.instruments: introduce instrument with mqtt-rpc to wb-mqtt-serial as a transport
   (instead of pyserial)
   * add --instrument launchkey (choosing modbus-calls backend; pyserial is default)
+    --instrument=rpc is temporarily disabled (is not supported in wb-mqtt-serial yet)
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Sun, 23 Oct 2022 21:19:25 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mcu-fw-updater (1.6.0) stable; urgency=medium
+
+  * wb_modbus.instruments: introduce instrument with mqtt-rpc to wb-mqtt-serial as a transport
+  (instead of pyserial)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Sun, 23 Oct 2022 21:19:25 +0300
+
 wb-mcu-fw-updater (1.5.2) stable; urgency=medium
 
   * update_monitor: support hex in slaveid parsing

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ wb-mcu-fw-updater (1.6.0) stable; urgency=medium
 
   * wb_modbus.instruments: introduce instrument with mqtt-rpc to wb-mqtt-serial as a transport
   (instead of pyserial)
+  * add --instrument launchkey (choosing modbus-calls backend; pyserial is default)
 
  -- Vladimir Romanov <v.romanov@wirenboard.ru>  Sun, 23 Oct 2022 21:19:25 +0300
 

--- a/debian/control
+++ b/debian/control
@@ -9,12 +9,12 @@ X-Python-Version: >= 2.7
 
 Package: python-wb-mcu-fw-updater
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, python-serial, python-yaml, python-tqdm, python-six, python-semantic-version, python-mosquitto (< 1.6), python-mqttrpc (>= 1.1.2)
+Depends: ${python:Depends}, ${misc:Depends}, python-serial, python-yaml, python-tqdm, python-six, python-semantic-version, python-mosquitto (< 1.6), python-mqttrpc (>= 1.1.2), wb-mqtt-serial (>= 2.69.4)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 2)
 
 Package: python3-wb-mcu-fw-updater
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-serial, python3-yaml, python3-tqdm, python3-six, python3-semantic-version, python3-paho-mqtt (< 1.6), python3-mqttrpc (>= 1.1.2)
+Depends: python3, ${misc:Depends}, python3-serial, python3-yaml, python3-tqdm, python3-six, python3-semantic-version, python3-paho-mqtt (< 1.6), python3-mqttrpc (>= 1.1.2), wb-mqtt-serial (>= 2.69.4)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 3)
 
 Package: wb-mcu-fw-updater

--- a/debian/control
+++ b/debian/control
@@ -9,12 +9,12 @@ X-Python-Version: >= 2.7
 
 Package: python-wb-mcu-fw-updater
 Architecture: all
-Depends: ${python:Depends}, ${misc:Depends}, python-serial, python-yaml, python-tqdm, python-six, python-semantic-version
+Depends: ${python:Depends}, ${misc:Depends}, python-serial, python-yaml, python-tqdm, python-six, python-semantic-version, python-mosquitto (< 1.6), python-mqttrpc (>= 1.1.2)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 2)
 
 Package: python3-wb-mcu-fw-updater
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-serial, python3-yaml, python3-tqdm, python3-six, python3-semantic-version
+Depends: python3, ${misc:Depends}, python3-serial, python3-yaml, python3-tqdm, python3-six, python3-semantic-version, python3-paho-mqtt (< 1.6), python3-mqttrpc (>= 1.1.2)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 3)
 
 Package: wb-mcu-fw-updater

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -10,6 +10,12 @@ from wb_modbus.instruments import StopbitsTolerantInstrument, SerialRPCBackendIn
 from wb_modbus import parse_uart_settings_str
 
 
+MODBUS_INSTRUMENTS = {
+    "pyserial" : StopbitsTolerantInstrument,
+    "rpc" : SerialRPCBackendInstrument
+}
+
+
 def check_internet_connection():
     try:
         fw_downloader.get_request(CONFIG['ROOT_URL'])
@@ -17,11 +23,12 @@ def check_internet_connection():
         die("%s is not accessible. Check Internet connection!" % CONFIG['ROOT_URL'])
 
 
-def _update_alive_device(slaveid, port, mode, response_timeout, branch, version, force, erase_settings):
+def _update_alive_device(slaveid, port, mode, response_timeout, branch, version, force, erase_settings,
+                            instrument=StopbitsTolerantInstrument):
     check_internet_connection()
 
     device_str = "(%s %d; response_timeout: %.2fs)" % (port, slaveid, response_timeout)
-    modbus_connection = WBModbusDeviceBase(slaveid, port, response_timeout=response_timeout, instrument=SerialRPCBackendInstrument)
+    modbus_connection = WBModbusDeviceBase(slaveid, port, response_timeout=response_timeout, instrument=instrument)
 
     is_in_bootloader = modbus_connection.is_in_bootloader()  # 9600N2
     if not is_in_bootloader:  # finding uart params
@@ -36,13 +43,13 @@ def _update_alive_device(slaveid, port, mode, response_timeout, branch, version,
         if is_in_bootloader:
             logger.info("Device %s supposed to be alive, but found in bootloader", device_str)
             logger.debug("Trying to acquire fw-signature...")
-            fw_sig = update_monitor._restore_fw_signature(slaveid, port, response_timeout)
+            fw_sig = update_monitor._restore_fw_signature(slaveid, port, response_timeout, instrument=instrument)
             if fw_sig:
                 downloaded_fw, fw_version = update_monitor._do_download(fw_sig, version, branch, mode,
                     retrieve_latest_vnum=False)  # we don't need any update-check here
                 logger.info("Will flash %s v:%s to bring %s %s alive", mode, fw_version, fw_sig, device_str)
                 update_monitor.direct_flash(downloaded_fw, modbus_connection.slaveid, modbus_connection.port,
-                    response_timeout, erase_all_settings=erase_settings, force=force)
+                    response_timeout, erase_all_settings=erase_settings, force=force, instrument=instrument)
                 if mode == "bootloader":  # we don't know fw's branch/version (only bl's ones)
                     update_monitor.recover_device_iteration(fw_sig, modbus_connection.slaveid,
                         modbus_connection.port, response_timeout, force)
@@ -70,14 +77,15 @@ def update_fw(args):
     # Could install specified fw_version from specified branch.
     version = args.specified_version or "release"
     _update_alive_device(slaveid=args.slaveid, port=args.port, mode='fw', response_timeout=args.response_timeout,
-        branch=args.branch_name, version=version, force=args.force, erase_settings=args.erase_settings)
+        branch=args.branch_name, version=version, force=args.force, erase_settings=args.erase_settings,
+        instrument=args.instrument)
 
 
 def update_bootloader(args):
     # Could install specified bl_version from specified branch.
     version = args.specified_version or "latest"  # no bl-releases.yaml yet
     _update_alive_device(slaveid=args.slaveid, port=args.port, mode='bootloader', response_timeout=args.response_timeout,
-        branch=args.branch_name, version=version, force=args.force, erase_settings=False)
+        branch=args.branch_name, version=version, force=args.force, erase_settings=False, instrument=args.instrument)
 
 
 def recover_fw(args):
@@ -89,22 +97,25 @@ def recover_fw(args):
     device_str = "%d %s" % (args.slaveid, args.port)
 
     if args.slaveid != 0:  # A broadcast-connected device does not answer to in-bootloader-probing cmd
-        device = WBModbusDeviceBase(args.slaveid, args.port, instrument=SerialRPCBackendInstrument, response_timeout=args.response_timeout)
+        device = WBModbusDeviceBase(args.slaveid, args.port, instrument=args.instrument, response_timeout=args.response_timeout)
         if not device.is_in_bootloader():
             die("Device (%s) is not in bootloader mode! Check connection or slaveid/port" % device_str)
 
     try:
         fw_signatures_list = fw_downloader.get_fw_signatures_list()
-        args.known_signature = args.known_signature or update_monitor._restore_fw_signature(args.slaveid, args.port, response_timeout=args.response_timeout)
+        args.known_signature = args.known_signature or update_monitor._restore_fw_signature(args.slaveid, args.port,
+            response_timeout=args.response_timeout, instrument=args.instrument)
 
         if args.known_signature:
-            update_monitor.recover_device_iteration(args.known_signature, args.slaveid, args.port, in_bl_response_timeout=args.response_timeout)
+            update_monitor.recover_device_iteration(args.known_signature, args.slaveid, args.port,
+                in_bl_response_timeout=args.response_timeout, instrument=args.instrument)
 
         elif update_monitor.ask_user('Try all possible fw_signatures (%s) for (%s); response_timeout: %.2f?' % (', '.join(fw_signatures_list), device_str, args.response_timeout)):
             for fw_sig in fw_signatures_list:
                 logger.info('Trying %s:', fw_sig)
                 try:
-                    update_monitor.recover_device_iteration(fw_sig, args.slaveid, args.port, in_bl_response_timeout=args.response_timeout)
+                    update_monitor.recover_device_iteration(fw_sig, args.slaveid, args.port,
+                        in_bl_response_timeout=args.response_timeout, instrument=args.instrument)
                     break
                 except fw_flasher.FlashingError:
                     continue
@@ -131,7 +142,8 @@ def update_all(args):
     """
     check_internet_connection()
     try:
-        update_monitor._update_all(force=args.force, minimal_response_timeout=args.minimal_response_timeout, allow_downgrade=args.allow_downgrade)
+        update_monitor._update_all(force=args.force, minimal_response_timeout=args.minimal_response_timeout,
+            allow_downgrade=args.allow_downgrade, instrument=args.instrument)
     except update_monitor.ConfigParsingError as e:
         die(e)
 
@@ -142,7 +154,8 @@ def recover_all(args):
     """
     check_internet_connection()
     try:
-        update_monitor._recover_all(minimal_response_timeout=args.minimal_response_timeout, force=args.force)
+        update_monitor._recover_all(minimal_response_timeout=args.minimal_response_timeout, force=args.force,
+            instrument=args.instrument)
     except update_monitor.ConfigParsingError as e:
         die(e)
 
@@ -153,7 +166,8 @@ def flash_fw_file(args):
     """
     device_str = "%s %d %s (response timeout: %.2f)" % (
                                 args.port, args.slaveid, str(args.conn_settings), args.response_timeout)
-    device = WBModbusDeviceBase(args.slaveid, args.port, *args.conn_settings, response_timeout=args.response_timeout, instrument=SerialRPCBackendInstrument)
+    device = WBModbusDeviceBase(args.slaveid, args.port, *args.conn_settings, response_timeout=args.response_timeout,
+        instrument=args.instrument)
     if not device.is_in_bootloader():
         logger.debug("Rebooting %s to bootloader", device_str)
         try:
@@ -162,7 +176,8 @@ def flash_fw_file(args):
             die("Device (%s) could not reboot to bootloader. Check connection params" % device_str)
 
     try:
-        update_monitor.direct_flash(args.fname, args.slaveid, args.port, args.response_timeout, args.erase_all, args.erase_uart)
+        update_monitor.direct_flash(args.fname, args.slaveid, args.port, args.response_timeout, args.erase_all,
+            args.erase_uart, instrument=args.instrument)
         return
     except fw_flasher.NotInBootloaderError as e:
         logger.error("Seems, device (%s) is not in bootloader mode", device_str)
@@ -186,6 +201,9 @@ def add_common_logic_args(parser):
                                 help='Perform force device reflash, even if firmware is latest. (Default: %(default)s)')
     parser.add_argument('--debug', dest='user_loglevel', default=None, action='store_const',
                                 const=10, help='Setting the least loglevel. (Default: %(default)s)')
+    parser.add_argument("--instrument", type=str, dest="instrument", default="pyserial",
+                                metavar="<connection backend>", choices=MODBUS_INSTRUMENTS.keys(),
+                                help="Connection backend for modbus calls. (Default: %(default)s)")
 
 
 def add_modbus_connection_args(parser):
@@ -292,14 +310,18 @@ if __name__ == "__main__":
     user_log.setup_user_logger("wb_mcu_fw_updater", user_loglevel)
     user_log.setup_user_logger("wb_modbus", user_loglevel)
 
-    # update_monitor.pause_driver()
-    # atexit.register(update_monitor.resume_driver)
+    args.instrument = MODBUS_INSTRUMENTS[args.instrument]
+
+    if args.instrument == StopbitsTolerantInstrument:
+        update_monitor.pause_driver()
+        atexit.register(update_monitor.resume_driver)
+
+        if "port" in vars(args):
+            initial_port_settings = update_monitor.get_port_settings(args.port)
+            atexit.register(lambda: update_monitor.set_port_settings(args.port, initial_port_settings))
+
     atexit.register(update_monitor.db.dump)
 
     update_monitor.fill_release_info()
-
-    # if 'port' in vars(args):
-    #     initial_port_settings = update_monitor.get_port_settings(args.port)
-    #     atexit.register(lambda: update_monitor.set_port_settings(args.port, initial_port_settings))
 
     args.func(args)

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -12,7 +12,7 @@ from wb_modbus import parse_uart_settings_str
 
 MODBUS_INSTRUMENTS = {
     "pyserial" : StopbitsTolerantInstrument,
-    "rpc" : SerialRPCBackendInstrument
+    # "rpc" : SerialRPCBackendInstrument  # is not fully supported in wb-mqtt-serial now
 }
 
 

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -6,7 +6,7 @@ import atexit
 from wb_mcu_fw_updater import fw_downloader, update_monitor, user_log, die, fw_flasher, CONFIG, logger
 from wb_modbus.bindings import WBModbusDeviceBase, TooOldDeviceError
 from wb_modbus.minimalmodbus import ModbusException
-from wb_modbus.instruments import StopbitsTolerantInstrument
+from wb_modbus.instruments import StopbitsTolerantInstrument, SerialRPCBackendInstrument
 from wb_modbus import parse_uart_settings_str
 
 
@@ -21,7 +21,7 @@ def _update_alive_device(slaveid, port, mode, response_timeout, branch, version,
     check_internet_connection()
 
     device_str = "(%s %d; response_timeout: %.2fs)" % (port, slaveid, response_timeout)
-    modbus_connection = WBModbusDeviceBase(slaveid, port, response_timeout=response_timeout)
+    modbus_connection = WBModbusDeviceBase(slaveid, port, response_timeout=response_timeout, instrument=SerialRPCBackendInstrument)
 
     is_in_bootloader = modbus_connection.is_in_bootloader()  # 9600N2
     if not is_in_bootloader:  # finding uart params
@@ -89,7 +89,7 @@ def recover_fw(args):
     device_str = "%d %s" % (args.slaveid, args.port)
 
     if args.slaveid != 0:  # A broadcast-connected device does not answer to in-bootloader-probing cmd
-        device = WBModbusDeviceBase(args.slaveid, args.port, instrument=StopbitsTolerantInstrument, response_timeout=args.response_timeout)
+        device = WBModbusDeviceBase(args.slaveid, args.port, instrument=SerialRPCBackendInstrument, response_timeout=args.response_timeout)
         if not device.is_in_bootloader():
             die("Device (%s) is not in bootloader mode! Check connection or slaveid/port" % device_str)
 
@@ -153,7 +153,7 @@ def flash_fw_file(args):
     """
     device_str = "%s %d %s (response timeout: %.2f)" % (
                                 args.port, args.slaveid, str(args.conn_settings), args.response_timeout)
-    device = WBModbusDeviceBase(args.slaveid, args.port, *args.conn_settings, response_timeout=args.response_timeout)
+    device = WBModbusDeviceBase(args.slaveid, args.port, *args.conn_settings, response_timeout=args.response_timeout, instrument=SerialRPCBackendInstrument)
     if not device.is_in_bootloader():
         logger.debug("Rebooting %s to bootloader", device_str)
         try:
@@ -292,14 +292,14 @@ if __name__ == "__main__":
     user_log.setup_user_logger("wb_mcu_fw_updater", user_loglevel)
     user_log.setup_user_logger("wb_modbus", user_loglevel)
 
-    update_monitor.pause_driver()
-    atexit.register(update_monitor.resume_driver)
+    # update_monitor.pause_driver()
+    # atexit.register(update_monitor.resume_driver)
     atexit.register(update_monitor.db.dump)
 
     update_monitor.fill_release_info()
 
-    if 'port' in vars(args):
-        initial_port_settings = update_monitor.get_port_settings(args.port)
-        atexit.register(lambda: update_monitor.set_port_settings(args.port, initial_port_settings))
+    # if 'port' in vars(args):
+    #     initial_port_settings = update_monitor.get_port_settings(args.port)
+    #     atexit.register(lambda: update_monitor.set_port_settings(args.port, initial_port_settings))
 
     args.func(args)

--- a/wb_mcu_fw_updater/fw_flasher.py
+++ b/wb_mcu_fw_updater/fw_flasher.py
@@ -5,7 +5,7 @@ import os
 import six
 from tqdm import tqdm
 from wb_modbus import minimalmodbus, bindings
-from wb_modbus.instruments import StopbitsTolerantInstrument
+from wb_modbus.instruments import SerialRPCBackendInstrument
 from . import logger
 
 
@@ -41,7 +41,7 @@ class ModbusInBlFlasher(object):
     MINIMAL_RESPONSE_TIMEOUT = 5.0  # should be relatively huge (for wireless devices)
 
     def __init__(self, addr, port, response_timeout, bd=9600, parity='N', stopbits=2):
-        self.instrument = bindings.WBModbusDeviceBase(addr, port, bd, parity, stopbits, instrument=StopbitsTolerantInstrument, foregoing_noise_cancelling=True)
+        self.instrument = bindings.WBModbusDeviceBase(addr, port, bd, parity, stopbits, instrument=SerialRPCBackendInstrument, foregoing_noise_cancelling=True)
         self._actual_response_timeout = max(self.MINIMAL_RESPONSE_TIMEOUT, response_timeout)
         self.instrument.set_response_timeout(self._actual_response_timeout)
 

--- a/wb_mcu_fw_updater/fw_flasher.py
+++ b/wb_mcu_fw_updater/fw_flasher.py
@@ -5,7 +5,7 @@ import os
 import six
 from tqdm import tqdm
 from wb_modbus import minimalmodbus, bindings
-from wb_modbus.instruments import SerialRPCBackendInstrument
+from wb_modbus.instruments import StopbitsTolerantInstrument
 from . import logger
 
 
@@ -40,8 +40,10 @@ class ModbusInBlFlasher(object):
 
     MINIMAL_RESPONSE_TIMEOUT = 5.0  # should be relatively huge (for wireless devices)
 
-    def __init__(self, addr, port, response_timeout, bd=9600, parity='N', stopbits=2):
-        self.instrument = bindings.WBModbusDeviceBase(addr, port, bd, parity, stopbits, instrument=SerialRPCBackendInstrument, foregoing_noise_cancelling=True)
+    def __init__(self, addr, port, response_timeout, bd=9600, parity='N', stopbits=2,
+        instrument=StopbitsTolerantInstrument):
+        self.instrument = bindings.WBModbusDeviceBase(addr, port, bd, parity, stopbits, instrument=instrument,
+            foregoing_noise_cancelling=True)
         self._actual_response_timeout = max(self.MINIMAL_RESPONSE_TIMEOUT, response_timeout)
         self.instrument.set_response_timeout(self._actual_response_timeout)
 

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -121,8 +121,9 @@ def download_fw_fallback(fw_signature, release_info, ask_for_latest=True, force=
     return downloaded_fw
 
 
-def find_connection_params(slaveid, port, response_timeout):
-    modbus_connection = bindings.WBModbusDeviceBase(slaveid, port, response_timeout=response_timeout, instrument=instruments.SerialRPCBackendInstrument)
+def find_connection_params(slaveid, port, response_timeout, instrument=instruments.StopbitsTolerantInstrument):
+    modbus_connection = bindings.WBModbusDeviceBase(slaveid, port, response_timeout=response_timeout,
+        instrument=instrument)
     logger.info("Will find serial port settings for (%s : %d; response_timeout: %.2f)...",
                                     port, slaveid, response_timeout)
     try:
@@ -166,19 +167,20 @@ def check_device_is_a_wb_one(modbus_connection):
         raise ForeignDeviceError("Possibly, device (%s %d) is not a WB-one!" % (modbus_connection.port, modbus_connection.slaveid))
 
 
-def get_correct_modbus_connection(slaveid, port, response_timeout, known_uart_params_str=None):  # TODO: to device_prober module?
+def get_correct_modbus_connection(slaveid, port, response_timeout, known_uart_params_str=None,
+    instrument=instruments.StopbitsTolerantInstrument):  # TODO: to device_prober module?
     """
     Alive device only:
         searching device's uart settings (if not passed);
         checking, that device is a wb-one via reading device_signature, serial_number, fw_signature, fw_version
     """
     modbus_connection = bindings.WBModbusDeviceBase(slaveid, port, response_timeout=response_timeout,
-        instrument=instruments.SerialRPCBackendInstrument)
+        instrument=instrument)
 
     if known_uart_params_str:
         modbus_connection.set_port_settings(*parse_uart_settings_str(known_uart_params_str))
     else:
-        raw_uart_params = find_connection_params(slaveid, port, response_timeout)
+        raw_uart_params = find_connection_params(slaveid, port, response_timeout, instrument=instrument)
         modbus_connection._set_port_settings_raw(raw_uart_params)
 
     check_device_is_a_wb_one(modbus_connection)
@@ -222,15 +224,17 @@ def get_devices_on_driver(driver_config_fname):  # TODO: move to separate module
     return found_devices
 
 
-def recover_device_iteration(fw_signature, slaveid, port, in_bl_response_timeout, force=False):
+def recover_device_iteration(fw_signature, slaveid, port, in_bl_response_timeout, force=False,
+    instrument=instruments.StopbitsTolerantInstrument):
     """
     A device supposed to be in "dead" state => fw_signature, slaveid, port have passed instead of modbus_connection
     """
     downloaded_fw = download_fw_fallback(fw_signature, RELEASE_INFO, force=force)
-    direct_flash(downloaded_fw, slaveid, port, response_timeout=in_bl_response_timeout, force=force)
+    direct_flash(downloaded_fw, slaveid, port, response_timeout=in_bl_response_timeout, force=force, instrument=instrument)
 
 
-def direct_flash(fw_fpath, slaveid, port, response_timeout, erase_all_settings=False, erase_uart_only=False, force=False):
+def direct_flash(fw_fpath, slaveid, port, response_timeout, erase_all_settings=False, erase_uart_only=False,
+    force=False, instrument=instruments.StopbitsTolerantInstrument):
     """
     Performing operations in bootloader (device is already into):
         flashing .wbfw
@@ -244,7 +248,7 @@ def direct_flash(fw_fpath, slaveid, port, response_timeout, erase_all_settings=F
 
     default_msg = "Device's settings will be reset to defaults (1, 9600-8-N-2). Are you sure?"
 
-    flasher = fw_flasher.ModbusInBlFlasher(slaveid, port, response_timeout=response_timeout)
+    flasher = fw_flasher.ModbusInBlFlasher(slaveid, port, response_timeout=response_timeout, instrument=instrument)
 
     if (erase_uart_only and _ensure(default_msg)):
         flasher.reset_uart()
@@ -322,16 +326,17 @@ def _do_download(fw_sig, version, branch, mode, retrieve_latest_vnum=True):
 
 def _do_flash(modbus_connection, fw_fpath, mode, erase_settings, force=False):
     fw_signature = modbus_connection.get_fw_signature()
+    instrument = modbus_connection.instrument
     logger.debug('Flashing approved for "%s" (%s : %d)', fw_signature, modbus_connection.port, modbus_connection.slaveid)
     modbus_connection.reboot_to_bootloader()
     direct_flash(fw_fpath, modbus_connection.slaveid, modbus_connection.port, modbus_connection.response_timeout,
-        erase_settings, force=force)
+        erase_settings, force=force, instrument=instrument)
 
     if mode == 'bootloader':
         logger.info('Bootloader was successfully flashed. Will flash released firmware for "%s"', fw_signature)
         downloaded_fw = download_fw_fallback(fw_signature, RELEASE_INFO, force=force)
         direct_flash(downloaded_fw, modbus_connection.slaveid, modbus_connection.port,
-            modbus_connection.response_timeout, erase_settings, force=force)
+            modbus_connection.response_timeout, erase_settings, force=force, instrument=instrument)
 
 
 def flash_alive_device(modbus_connection, mode, branch_name, specified_fw_version, force, erase_settings):
@@ -385,7 +390,7 @@ class DeviceInfo(namedtuple('DeviceInfo', ['name', 'modbus_connection'])):
         return "%s (%d, %s)" % (self.name, self.modbus_connection.slaveid, self.modbus_connection.port)
 
 
-def probe_all_devices(driver_config_fname, minimal_response_timeout):  # TODO: rework entire data model (to get rid of passing lists)
+def probe_all_devices(driver_config_fname, minimal_response_timeout, instrument=instruments.StopbitsTolerantInstrument):  # TODO: rework entire data model (to get rid of passing lists)
     """
     Acquiring states of all devies, added to config.
     States could be:
@@ -405,14 +410,16 @@ def probe_all_devices(driver_config_fname, minimal_response_timeout):  # TODO: r
         for device_name, device_slaveid, device_response_timeout in devices_on_port:
             actual_response_timeout = max(minimal_response_timeout, port_response_timeout, device_response_timeout)
             logger.info('Probing %s (port: %s, slaveid: %d, uart_params: %s, response_timeout: %.2f)...', device_name, port, device_slaveid, uart_params, actual_response_timeout)
-            device_info = DeviceInfo(name=device_name, modbus_connection=bindings.WBModbusDeviceBase(device_slaveid, port, *parse_uart_settings_str(uart_params), response_timeout=actual_response_timeout, instrument=instruments.SerialRPCBackendInstrument))
+            device_info = DeviceInfo(name=device_name, modbus_connection=bindings.WBModbusDeviceBase(device_slaveid, port,
+                *parse_uart_settings_str(uart_params), response_timeout=actual_response_timeout, instrument=instrument))
             try:
-                device_info = DeviceInfo(name=device_name, modbus_connection=get_correct_modbus_connection(device_slaveid, port, actual_response_timeout, uart_params))
+                device_info = DeviceInfo(name=device_name, modbus_connection=get_correct_modbus_connection(device_slaveid, port, actual_response_timeout, uart_params, instrument=instrument))
             except ForeignDeviceError as e:
                 result['foreign'].append(device_info)
                 continue
             except minimalmodbus.NoResponseError as e:
-                bootloader_connection = bindings.WBModbusDeviceBase(device_slaveid, port, response_timeout=actual_response_timeout, instrument=instruments.SerialRPCBackendInstrument)
+                bootloader_connection = bindings.WBModbusDeviceBase(device_slaveid, port,
+                    response_timeout=actual_response_timeout, instrument=instrument)
                 if bootloader_connection.is_in_bootloader():
                     result['in_bootloader'].append(DeviceInfo(name=device_name, modbus_connection=bootloader_connection))
                 else:
@@ -436,8 +443,9 @@ def print_status(loglevel, status='', devices_list=[], additional_info=''):
     logger.log(loglevel, additional_info)
 
 
-def _update_all(force, minimal_response_timeout, allow_downgrade=False):  # TODO: maybe store fw endpoint in device_info? (to prevent multiple releases-parsing)
-    probing_result = probe_all_devices(CONFIG['SERIAL_DRIVER_CONFIG_FNAME'], minimal_response_timeout)
+def _update_all(force, minimal_response_timeout, allow_downgrade=False,
+    instrument=instruments.StopbitsTolerantInstrument):  # TODO: maybe store fw endpoint in device_info? (to prevent multiple releases-parsing)
+    probing_result = probe_all_devices(CONFIG['SERIAL_DRIVER_CONFIG_FNAME'], minimal_response_timeout, instrument=instrument)
     cmd_status = defaultdict(list)
 
     for device_info in probing_result['alive']:
@@ -478,14 +486,16 @@ def _update_all(force, minimal_response_timeout, allow_downgrade=False):  # TODO
             cmd_status['ok'].append(device_info)
 
     for device_info in probing_result['in_bootloader'][:]:
-        fw_signature = _restore_fw_signature(device_info.modbus_connection.slaveid, device_info.modbus_connection.port, device_info.modbus_connection.response_timeout)
+        fw_signature = _restore_fw_signature(device_info.modbus_connection.slaveid, device_info.modbus_connection.port,
+            device_info.modbus_connection.response_timeout, instrument=instrument)
         logger.info("Found in bootloader: %s; fw_signature: %s", str(device_info), str(fw_signature))
         if not fw_signature:
             continue  # remain as in-bootloader
         try:
             recover_device_iteration(fw_signature, device_info.modbus_connection.slaveid,
                 device_info.modbus_connection.port,
-                in_bl_response_timeout=device_info.modbus_connection.response_timeout, force=force)
+                in_bl_response_timeout=device_info.modbus_connection.response_timeout, force=force,
+                instrument=instrument)
         except (fw_flasher.FlashingError, fw_downloader.WBRemoteStorageError) as e:
             logger.exception(e)
         else:
@@ -520,13 +530,14 @@ def _update_all(force, minimal_response_timeout, allow_downgrade=False):  # TODO
     )
 
 
-def _restore_fw_signature(slaveid, port, response_timeout):
+def _restore_fw_signature(slaveid, port, response_timeout, instrument=instruments.StopbitsTolerantInstrument):
     """
     Getting fw_signature of devices in bootloader
     """
     try:
         logger.debug("Will ask a bootloader for fw_signature")
-        fw_signature = bindings.WBModbusDeviceBase(slaveid, port, instrument=instruments.SerialRPCBackendInstrument, response_timeout=response_timeout).get_fw_signature()  # latest bootloaders could answer a fw_signature
+        fw_signature = bindings.WBModbusDeviceBase(slaveid, port, instrument=instrument,
+            response_timeout=response_timeout).get_fw_signature()  # latest bootloaders could answer a fw_signature
     except minimalmodbus.ModbusException as e:
         logger.debug("Will try to restore fw_signature from db by slaveid: %d and port %s", slaveid, port)
         fw_signature = db.get_fw_signature(slaveid, port)
@@ -534,12 +545,14 @@ def _restore_fw_signature(slaveid, port, response_timeout):
     return fw_signature
 
 
-def _recover_all(minimal_response_timeout, force=False):
-    probing_result = probe_all_devices(CONFIG['SERIAL_DRIVER_CONFIG_FNAME'], minimal_response_timeout)
+def _recover_all(minimal_response_timeout, force=False, instrument=instruments.StopbitsTolerantInstrument):
+    probing_result = probe_all_devices(CONFIG['SERIAL_DRIVER_CONFIG_FNAME'], minimal_response_timeout,
+        instrument=instrument)
     cmd_status = defaultdict(list)
 
     for device_info in probing_result['in_bootloader']:
-        fw_signature = _restore_fw_signature(device_info.modbus_connection.slaveid, device_info.modbus_connection.port, device_info.modbus_connection.response_timeout)
+        fw_signature = _restore_fw_signature(device_info.modbus_connection.slaveid, device_info.modbus_connection.port,
+            device_info.modbus_connection.response_timeout, instrument=instrument)
         if fw_signature is None:
             logger.info('%s %s', user_log.colorize('Unknown fw_signature:', 'RED'), str(device_info))
             cmd_status['skipped'].append(device_info)
@@ -553,7 +566,8 @@ def _recover_all(minimal_response_timeout, force=False):
             try:
                 recover_device_iteration(fw_signature, device_info.modbus_connection.slaveid,
                     device_info.modbus_connection.port,
-                    in_bl_response_timeout=device_info.modbus_connection.response_timeout, force=force)
+                    in_bl_response_timeout=device_info.modbus_connection.response_timeout, force=force,
+                    instrument=instrument)
             except (fw_flasher.FlashingError, fw_downloader.WBRemoteStorageError) as e:
                 logger.exception(e)
                 cmd_status['skipped'].append(device_info)

--- a/wb_modbus/instruments.py
+++ b/wb_modbus/instruments.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 import termios
+import atexit
 from contextlib import contextmanager
 import six
 import paho.mqtt.client as mosquitto
@@ -277,7 +278,11 @@ class PySerialMock(object):
         return wrapper
 
 
-class SeriaRPCBackendInstrument(minimalmodbus.Instrument):
+class SerialRPCBackendInstrument(minimalmodbus.Instrument):
+    __MQTT_CONNECTIONS = {}
+
+    DEFAULT_MQTT_HOST = "127.0.0.1"
+    DEFAULT_MQTT_PORT_STR = "1883"
     RPC_ERR_STATES = {
         "JSON_PARSE": -32700,
         "REQUEST_HANDLING": -32000,
@@ -285,19 +290,19 @@ class SeriaRPCBackendInstrument(minimalmodbus.Instrument):
     }
 
     def __init__(self, port, slaveaddress, **kwargs):
-        broker_addr = kwargs.get("broker_addr", "127.0.0.1:1883")
-        self.mqtt_host, self.mqtt_port = broker_addr.split(":", maxsplit=1)
-        self.mqtt_port = int(self.mqtt_port)
-        self.mqtt_client_name = "minimalmodbus-rpc-instrument_%d" % os.getpid()
+        self.broker_addr = kwargs.get("broker_addr", "%s:%s" % (self.DEFAULT_MQTT_HOST, self.DEFAULT_MQTT_PORT_STR))
+        self.mqtt_client_name = "minimalmodbus-rpc-instrument_%s_%d" % (self.broker_addr, os.getpid())
 
+        # required minimalmodbus's internals
         self.address = slaveaddress
         self.mode = kwargs.get("mode", minimalmodbus.MODE_RTU)
         self.precalculate_read_size = True
         self.debug = kwargs.get("debug", False)
         self.close_port_after_each_call = False
-        self.serial = PySerialMock()  # respect current .minimalmodbus & .bindings design
-
         self.port = port
+
+        # respect current .minimalmodbus & .bindings design
+        self.serial = PySerialMock()
         self.serial.port = port
 
     def __repr__(self):
@@ -318,19 +323,39 @@ class SeriaRPCBackendInstrument(minimalmodbus.Instrument):
             self.serial,
         )
 
-    @contextmanager
-    def init_mqtt_client(self):
-        try:
-            client = mosquitto.Mosquitto(self.mqtt_client_name)
-            logger.debug("Connecting: %s:%s", self.mqtt_host, self.mqtt_port)
-            client.connect(self.mqtt_host, self.mqtt_port)
-            client.loop_start()
-            yield client
-        except (TimeoutError, ConnectionRefusedError) as e:
-            six.raise_from(RPCConnectionError, e)
-        finally:
+    def parse_mqtt_addr(self, hostport_str):
+        host, port = hostport_str.split(":", maxsplit=1)
+        return host or self.DEFAULT_MQTT_HOST, int(port or self.DEFAULT_MQTT_PORT_STR, 0)
+
+    def close_mqtt(self, hostport_str):
+        client = self.__class__.__MQTT_CONNECTIONS.get(hostport_str)
+
+        if client:
             client.loop_stop()
             client.disconnect()
+            self.__class__.__MQTT_CONNECTIONS.pop(hostport_str)
+            logger.debug("Mqtt: close %s", hostport_str)
+        else:
+            logger.warning("Mqtt connection %s not found in active ones!", hostport_str)
+
+    @contextmanager
+    def get_mqtt_client(self, hostport_str):
+        client = self.__class__.__MQTT_CONNECTIONS.get(hostport_str)
+
+        if client:
+            yield client
+        else:
+            try:
+                client = mosquitto.Mosquitto(self.mqtt_client_name)
+                logger.debug("New mqtt connection: %s", hostport_str)
+                client.connect(*self.parse_mqtt_addr(hostport_str))
+                client.loop_start()
+                self.__class__.__MQTT_CONNECTIONS.update({hostport_str : client})
+                yield client
+            except (TimeoutError, ConnectionRefusedError) as e:
+                six.raise_from(RPCConnectionError, e)
+            finally:
+                atexit.register(lambda: self.close_mqtt(hostport_str))
 
     def _communicate(self, request, number_of_bytes_to_read):
         minimalmodbus._check_string(request, minlength=1, description="request")
@@ -346,16 +371,14 @@ class SeriaRPCBackendInstrument(minimalmodbus.Instrument):
             "path": self.serial.port  # TODO: somehow guess rtu or tcp?
         }
 
-        with self.init_mqtt_client() as mqtt_client:
+        with self.get_mqtt_client(self.broker_addr) as mqtt_client:
             rpc_call_timeout = 10
             try:
                 rpc_client = rpcclient.TMQTTRPCClient(mqtt_client)
                 mqtt_client.on_message = rpc_client.on_mqtt_message
-                # logger.debug("RPC Client -> %s (%d timeout ms)", rpc_request, rpc_call_timeout)
-                print("RPC Client -> %s (%d timeout ms)" % (str(rpc_request), rpc_call_timeout))
+                logger.debug("RPC Client -> %s (rpc timeout: %ds)", rpc_request, rpc_call_timeout)
                 response = rpc_client.call("wb-mqtt-serial", "port", "Load", rpc_request, rpc_call_timeout)
-                # logger.debug("RPC Client <- %s", response)
-                print("RPC Client <- %s" % str(response))
+                logger.debug("RPC Client <- %s", response)
             except rpcclient.MQTTRPCError as e:
                 reraise_err = minimalmodbus.NoResponseError if e.code == self.RPC_ERR_STATES["REQUEST_HANDLING"] else RPCCommunicationError
                 six.raise_from(reraise_err, e)


### PR DESCRIPTION
- wb-modbus: добавил транспорт через mqtt-rpc к wb-mqtt-serial'у. Всю логику разбирает minimalmodbus. Есть очень большая вероятность, что наша магия вокруг bindings и minimalmodbus не поломалась (гонял упдатер по разным сценариям, гонял руками - подозрительного не вижу). **Надо будет поддержать modbus-tcp в этом инструменте**

- упдатер: пропихнул instrument во все внутренние потроха. wb-mqtt-serial умеет еще не всё => --instrument=rpc пока сделал недоступным