### PR TITLE
wb_modbus.StopbitsTolerantInstrument: fix incorrect stopbits setting …

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.6.1) stable; urgency=medium
+
+  * wb_modbus.StopbitsTolerantInstrument: fix incorrect stopbits setting in WB7
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Sun, 27 Oct 2022 20:01:43 +0300
+
 wb-mcu-fw-updater (1.6.0) stable; urgency=medium
 
   * wb_modbus.instruments: introduce instrument with mqtt-rpc to wb-mqtt-serial as a transport

--- a/wb_modbus/instruments.py
+++ b/wb_modbus/instruments.py
@@ -234,18 +234,21 @@ class StopbitsTolerantInstrument(PyserialBackendInstrument):
 
     def _write_to_bus(self, request):
         """
-        Setting stopbits-to-receive just after all data-to-send goes out from output buffer
+        Set stopbits-to-receive after all data-to-send goes out from output buffer
         """
         self._initial_stopbits = self.serial._stopbits
         super(StopbitsTolerantInstrument, self)._write_to_bus(request)
         write_ts = time.time()
-        while self.serial.out_waiting > 0:
+        while (self.serial.out_waiting > 0) or (self.serial.in_waiting == 0):
             if time.time() - write_ts < self.serial.timeout:
                 time.sleep(0.1)
             else:
-                raise minimalmodbus.MasterReportedException(
-                    "Output serial buffer is not empty after %.2fs (serial.timeout)" % self.serial.timeout
-                )
+                if (self.serial.out_waiting == 0) and (self.serial.in_waiting == 0):
+                    raise minimalmodbus.NoResponseError("No communication with the instrument (no answer)")
+                else:
+                    raise minimalmodbus.MasterReportedException(
+                        "Output serial buffer is not empty after %.2fs (serial.timeout)" % self.serial.timeout
+                    )
         termios.tcdrain(self.serial.fd)  # ensuring, all buffered data has transmitted
         self._set_stopbits_onthefly(stopbits=1)
 


### PR DESCRIPTION
…in WB7

очередная детективная история :(
чтобы ходить через pyserial, у нас есть 2 инструмента: `PyserialBackendInstrument` и его наследник - `StopbitsTolerantInstrument` (всегда принимающий с одним стопбитиком)

`StopbitsTolerantInstrument` у нас раньше использовался только для операций с бутлоадером. В последних изменениях (вытаскивание instrument наружу), я лихо (сам забыл) сделал `StopbitsTolerantInstrument` инструментом по умолчанию для всего (а не только для бутлоадера) => на wb6 всё работает => ничто не предвещало беды

а wb7 оказался слишком быстрым => на нём ругается на crc, т.к. наша проверка конца передачи не срабатывает, и мы меняем стопбитики, не завершив передачу



=> предлагаю:
пусть уж `StopbitsTolerantInstrument` для всего, что не-rpc - так и выкатывается. Иначе есть риск второй раз так же забыть какую-то специфическую магию

т.е. не возвращать 2 разных инструмента (для бутлоадера и не для); думаю, будет безопасно, т.к. я хорошо гонял на wb6 перед выкатыванием предыдущего pr