### PR TITLE
Feature/mqtt serial updates

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mcu-fw-updater (1.6.2) stable; urgency=medium
+
+  * wb_modbus.SerialRPCBackendInstrument: add required data_bits param to rpc call
+  * recommend wb-mqtt-serial with rpc-support (instead of strict depend on)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 31 Oct 2022 22:21:47 +0300
+
 wb-mcu-fw-updater (1.6.1) stable; urgency=medium
 
   * wb_modbus.StopbitsTolerantInstrument: fix incorrect stopbits setting in WB7

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,8 @@ X-Python-Version: >= 3.9.1
 
 Package: python3-wb-mcu-fw-updater
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-serial, python3-yaml, python3-tqdm, python3-six, python3-semantic-version, python3-paho-mqtt, python3-mqttrpc (>= 1.1.2), wb-mqtt-serial (>= 2.73.0)
+Depends: python3, ${misc:Depends}, python3-serial, python3-yaml, python3-tqdm, python3-six, python3-semantic-version, python3-paho-mqtt, python3-mqttrpc (>= 1.1.2)
+Recommends: wb-mqtt-serial (>= 2.73.0)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 3)
 
 Package: wb-mcu-fw-updater

--- a/wb_modbus/instruments.py
+++ b/wb_modbus/instruments.py
@@ -397,6 +397,7 @@ class SerialRPCBackendInstrument(minimalmodbus.Instrument):
             "path": self.serial.port,  # TODO: support modbus tcp in minimalmodbus
             "baud_rate" : self.serial.SERIAL_SETTINGS["baudrate"],
             "parity" : self.serial.SERIAL_SETTINGS["parity"],
+            "data_bits" : 8,
             "stop_bits" : self.serial.SERIAL_SETTINGS["stopbits"],
         }
 


### PR DESCRIPTION
убрал жесткую зависимость от сериала (мешало wb-device-manager при сборке)
добавил ставшее обязательным (в последнем PR в сериал) поле в rpc-запрос