### PR TITLE
update_monitor: fix Neva slaveid parsing in serial config

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.6.3) stable; urgency=medium
+
+  * update_monitor: fix Neva slaveid parsing in serial config
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 15 Dec 2022 15:17:22 +0300
+
 wb-mcu-fw-updater (1.6.2) stable; urgency=medium
 
   * wb_modbus.SerialRPCBackendInstrument: add required data_bits param to rpc call

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -216,11 +216,13 @@ def get_devices_on_driver(driver_config_fname):  # TODO: move to separate module
                     logger.debug("Has found WBIO device: %s", device_name)
                     device_name, slaveid = 'WB-MIO', slaveid.split(':')[0]  # mio_slaveid:device_order
                 try:
-                    devices_on_port.add((device_name, int(slaveid, 0), device_response_timeout))
+                    parsed_slaveid = int(slaveid, 0)
                 except ValueError:
-                    logger.warning(
+                    logger.info(
                         'Device ("%s" %s) on %s seems not to be a WB-one; skipping', device_name, slaveid, port_name
                         )
+                    continue
+                devices_on_port.add((device_name, parsed_slaveid, device_response_timeout))
             if devices_on_port:
                 found_devices.update({port_name : {'devices' : list(devices_on_port), 'uart_params' : uart_params_of_port, 'response_timeout' : port_response_timeout}})
 


### PR DESCRIPTION
у Невы довольно странный формат slaveid (её серийник; c 0000 вначале)
и int(slaveid, 0) это не нравится