### PR TITLE
Support connection to Mosquitto through unix socket

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.7.0) stable; urgency=medium
+
+  * Support connection to Mosquitto through unix socket
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 28 Feb 2023 16:44:00 +0400
+
 wb-mcu-fw-updater (1.6.6) stable; urgency=medium
 
   * Fix formatting

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wb-mcu-fw-updater (1.7.0) stable; urgency=medium
 
   * Support connection to Mosquitto through unix socket
+  * Use mqtt client wrapper from wb-common
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 28 Feb 2023 16:44:00 +0400
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ X-Python-Version: >= 3.9.1
 
 Package: python3-wb-mcu-fw-updater
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-serial, python3-yaml, python3-tqdm, python3-six, python3-semantic-version, python3-paho-mqtt, python3-mqttrpc (>= 1.1.2)
+Depends: python3, ${misc:Depends}, python3-serial, python3-yaml, python3-tqdm, python3-six, python3-semantic-version, python3-wb-common (>= 2.1.0), python3-mqttrpc (>= 1.1.2)
 Recommends: wb-mqtt-serial (>= 2.73.0)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 3)
 

--- a/wb_modbus/instruments.py
+++ b/wb_modbus/instruments.py
@@ -356,7 +356,7 @@ class SerialRPCBackendInstrument(minimalmodbus.Instrument):
         client = self.mqtt_connections.get(broker_url)
 
         if client:
-            client.disconnect()
+            client.stop()
             self.mqtt_connections.pop(broker_url)
             logger.debug("Mqtt: close %s", broker_url)
         else:
@@ -372,7 +372,7 @@ class SerialRPCBackendInstrument(minimalmodbus.Instrument):
             try:
                 client = MQTTClient(self.mqtt_client_name, broker_url)
                 logger.debug("New mqtt connection: %s", broker_url)
-                client.connect()
+                client.start()
                 self.mqtt_connections.update({broker_url: client})
                 yield client
             except (rpcclient.TimeoutError, OSError) as e:


### PR DESCRIPTION
Depends on https://github.com/wirenboard/wb-common/pull/8

Test instructions:
```sh
$ wb-mcu-fw-updater update-fw --instrument rpc --debug -a 31 /dev/ttyRS485-1
...
2023-03-01 15:31:20,472 New mqtt connection: unix:///var/run/mosquitto/mosquitto.sock
2023-03-01 15:31:20,477 RPC Client -> {'response_size': 7, 'format': 'HEX', 'msg': '1F0300800001865C', 'response_timeout': 500, 'path': '/dev/ttyRS485-1', 'baud_rate': 9600, 'parity': 'N', 'data_bits': 8, 'stop_bits': 2} (rpc timeout: 10s)
2023-03-01 15:31:20,513 RPC Client <- {'response': '1f0302001f518e'}
...
2023-03-01 15:31:23,043 Done
2023-03-01 15:31:23,145 Mqtt: close unix:///var/run/mosquitto/mosquitto.sock
...
```