### PR TITLE
wb_modbus: add "_probe_func" param around internal magic "is_in_bootl…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.7.1) stable; urgency=medium
+
+  * wb_modbus: add "_probe_func" param around internal magic "is_in_bootloader" methods
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Fri, 03 Mar 2023 13:35:11 +0300
+
 wb-mcu-fw-updater (1.7.0) stable; urgency=medium
 
   * Support connection to Mosquitto through unix socket


### PR DESCRIPTION
В рамках тыжпрограммистства, комана test-suite попросила помочь с ускорением тестов. Посмотрел - есть давняя проблема: [вот эти](https://github.com/wirenboard/wb-mcu-fw-updater/blob/6d695a171d09c342932f34cef20a533a65880fb0/wb_modbus/__init__.py#L11) retries. Т.к. под капотом у wb-modbus всё сделано на декораторах - нельзя так просто взять и уменьшить их количество.

Думаю, предпринимать серьёзные изменения, чтобы сделать хорошо - не стоит; поэтому - вытащил пару магических параметров

[Зачем всё это](https://github.com/wirenboard/test-suite/pull/319)