### PR TITLE
Add cli argument to specify MQTT connection URL

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.8.1) stable; urgency=medium
+
+  * Add cli argument to specify MQTT connection URL
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Thu, 01 Jun 2023 19:14:00 +0400
+
 wb-mcu-fw-updater (1.8.0) stable; urgency=medium
 
   * Check (and pause) all port users

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -4,6 +4,8 @@
 import argparse
 import atexit
 
+from wb_common.mqtt_client import DEFAULT_BROKER_URL
+
 from wb_mcu_fw_updater import (
     CONFIG,
     die,
@@ -308,6 +310,14 @@ def add_common_logic_args(parser):
         choices=MODBUS_INSTRUMENTS.keys(),
         help="Connection backend for modbus calls. (Default: %(default)s)",
     )
+    parser.add_argument(
+        "--broker",
+        type=str,
+        dest="broker",
+        default=DEFAULT_BROKER_URL,
+        metavar="<broker>",
+        help="MQTT broker url. (Default: %(default)s)",
+    )
 
 
 def add_modbus_connection_args(parser):
@@ -518,6 +528,8 @@ if __name__ == "__main__":
         if "port" in vars(args):
             initial_port_settings = update_monitor.get_port_settings(args.port)
             atexit.register(lambda: update_monitor.set_port_settings(args.port, initial_port_settings))
+    elif args.instrument == SerialRPCBackendInstrument:
+        SerialRPCBackendInstrument._MQTT_BROKER_URL = args.broker
 
     atexit.register(update_monitor.db.dump)
 

--- a/wb_modbus/instruments.py
+++ b/wb_modbus/instruments.py
@@ -312,12 +312,13 @@ class SerialRPCBackendInstrument(minimalmodbus.Instrument):
     (instead of pyserial)
     """
 
+    _MQTT_BROKER_URL = DEFAULT_BROKER_URL
     _MQTT_CONNECTIONS = {}
 
     RPC_ERR_STATES = {"JSON_PARSE": -32700, "REQUEST_HANDLING": -32000, "REQUEST_TIMEOUT": -32100}
 
     def __init__(self, port, slaveaddress, **kwargs):
-        self.broker_url = kwargs.get("broker", DEFAULT_BROKER_URL)
+        self.broker_url = kwargs.get("broker", self._MQTT_BROKER_URL)
         self.mqtt_client_name = "minimalmodbus-rpc-instrument"
 
         # required minimalmodbus's internals


### PR DESCRIPTION
Test instruction:
```sh
$ wb-mcu-fw-updater update-all --instrument rpc --broker tcp://127.0.0.1:1883
<...>
$ wb-mcu-fw-updater update-all -h
usage: wb-mcu-fw-updater update-all [-h] [--allow-downgrade] [-T <minimal_response_timeout>] [-f] [--debug]
                                    [--instrument <connection backend>] [--broker <broker>]

optional arguments:
  -h, --help            show this help message and exit
  --allow-downgrade     Firmware versions could be downgraded. (Default: False)
  -T <minimal_response_timeout>, --min-response-timeout <minimal_response_timeout>
                        Minimal modbus response timeout. Actual response timeout is: MAX(min_response_timeout, wb-mqtt-serial's response
                        timeouts) (Default: 0.5)
  -f, --force           Perform force device reflash, even if firmware is latest. (Default: False)
  --debug               Setting the least loglevel. (Default: None)
  --instrument <connection backend>
                        Connection backend for modbus calls. (Default: pyserial)
  --broker <broker>     MQTT broker url. (Default: unix:///var/run/mosquitto/mosquitto.sock)
```