### PR TITLE
Add package publication to devTools repo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,2 @@
-buildDebArchAll defaultRunPythonChecks: true
+buildDebArchAll defaultRunPythonChecks: true,
+                repos: ['release', 'devTools']


### PR DESCRIPTION
нужно для установки зависимостей в test-suite-ng