### PR TITLE
fix versions comparing when updating bootloader from master

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.8.5) stable; urgency=medium
+
+  * Fix versions comparing when updating bootloader from master
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 04 Oct 2023 10:03:21 +0300
+
 wb-mcu-fw-updater (1.8.4) stable; urgency=medium
 
   * Print fw version if updating from branch

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -446,8 +446,6 @@ def _do_download(fw_sig, version, branch, mode, retrieve_latest_vnum=True):
         mode_name = "firmware"
     else:
         mode_name = "bootloader"
-        # TODO: put unstable_bl version to latest.txt on ci; then remove "retrieve_latest_vnum" logic (task 51352)
-        retrieve_latest_vnum = False
 
     downloaded_fw = None
 
@@ -457,6 +455,9 @@ def _do_download(fw_sig, version, branch, mode, retrieve_latest_vnum=True):
         ):  # default fw_version now is 'release'; will flash latest, if branch has specified
             version = "latest"
             downloaded_fw = downloader.download(fw_sig, version)
+        if mode_name == "bootloader":
+            retrieve_latest_vnum = False
+            # TODO: put unstable_bl version to latest.txt on ci; then remove "retrieve_latest_vnum" logic (task 51352)
 
     if version == "release":  # triggered updating from releases
         version, released_fw_endpoint = get_released_fw(fw_sig, RELEASE_INFO)


### PR DESCRIPTION
проблема: машинерия эмбеддеров не кладёт крайнюю версию бутлоадера в latest.txt при сборке его из ветки

в упдатере исторически есть костыль для этого в виде "retrieve_latest_vnum" логики

с последними изменениями я прошляпил и вытащил костыль на уровень выше - т.е. и лля веток, и для мастера
проверял прошивку бутлоадера из ветки, но не из мастера => всё и взорвалось