### PR TITLE
Feature/71178 no bl downgrade

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.10.1) stable; urgency=medium
+
+  * Bootloader downgrade is not allowed
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 23 Jan 2024 16:02:21 +0300
+
 wb-mcu-fw-updater (1.10.0) stable; urgency=medium
 
   * update-fw / update-all: suggest to update bootloader if running from interactive shell

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -509,10 +509,13 @@ def is_interactive_shell():
 
 
 def is_bl_update_required(modbus_connection, force=False):
-    if is_bootloader_latest(modbus_connection):
+    fw_sig = modbus_connection.get_fw_signature()
+    local_version = modbus_connection.get_bootloader_version()
+    remote_version = fw_downloader.RemoteFileWatcher(mode=MODE_BOOTLOADER).get_latest_version_number(fw_sig)
+    if semantic_version.Version(local_version) == semantic_version.Version(remote_version):
         return False
     suggestion_str = (
-        f"Bootloader update for {modbus_connection.get_fw_signature()} "
+        f"Bootloader update (v{local_version} -> v{remote_version}) for {fw_sig} "
         f"{modbus_connection.port}:{modbus_connection.slaveid} is available! "
         "(bootloader updates are highly recommended to install)"
     )


### PR DESCRIPTION
@nikitoz236 хотел видеть версии при обновлении бутлоадера:
![image](https://github.com/wirenboard/wb-mcu-fw-updater/assets/25829054/d197cf71-fcee-4aa9-93eb-9c6c94ea7253)


также - решили запретить даунгрейд бутлоадеров, т.к. особо неудачные девайсы могут совсем окирпичиться из-за неправильного i2c-адреса eeprom:
![image](https://github.com/wirenboard/wb-mcu-fw-updater/assets/25829054/36aef612-5b10-40f6-a3fa-2abe50f03533)
