### PR TITLE
Bugfix/custom uart params

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.10.3) stable; urgency=medium
+
+  * Fix bootloader updating issues on custom uart params
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 25 Jan 2024 15:32:51 +0300
+
 wb-mcu-fw-updater (1.10.2) stable; urgency=medium
 
   * Bootloader downgrade is not allowed

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -75,7 +75,13 @@ def _update_alive_device(
                 downloaded_wbfw = update_monitor._do_download(
                     fw_sig, version, branch, mode, retrieve_latest_vnum=False
                 )  # we don't need any update-check here
-                logger.info("Will flash %s v:%s to bring %s %s alive", mode, downloaded_wbfw.version, fw_sig, device_str)
+                logger.info(
+                    "Will flash %s v%s to bring %s %s alive",
+                    mode,
+                    downloaded_wbfw.version,
+                    fw_sig,
+                    device_str,
+                )
                 update_monitor.direct_flash(
                     downloaded_wbfw.fpath, modbus_connection, erase_all_settings=erase_settings, force=force
                 )

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -72,12 +72,12 @@ def _update_alive_device(
             logger.debug("Trying to acquire fw-signature...")
             fw_sig = update_monitor._restore_fw_signature(modbus_connection)
             if fw_sig:
-                downloaded_fw, fw_version = update_monitor._do_download(
+                downloaded_wbfw = update_monitor._do_download(
                     fw_sig, version, branch, mode, retrieve_latest_vnum=False
                 )  # we don't need any update-check here
-                logger.info("Will flash %s v:%s to bring %s %s alive", mode, fw_version, fw_sig, device_str)
+                logger.info("Will flash %s v:%s to bring %s %s alive", mode, downloaded_wbfw.version, fw_sig, device_str)
                 update_monitor.direct_flash(
-                    downloaded_fw, modbus_connection, erase_all_settings=erase_settings, force=force
+                    downloaded_wbfw.fpath, modbus_connection, erase_all_settings=erase_settings, force=force
                 )
                 if mode == MODE_BOOTLOADER:  # we don't know fw's branch/version (only bl's ones)
                     update_monitor.recover_device_iteration(fw_sig, modbus_connection, force)

--- a/wb_mcu_fw_updater/fw_flasher.py
+++ b/wb_mcu_fw_updater/fw_flasher.py
@@ -180,9 +180,7 @@ class ModbusInBlFlasher(object):
         """
         device_str = f"{self.instrument.slaveid}, {self.instrument.port}"
         try:
-            available_chunks_fs = self.instrument.device.read_register(
-                self.GET_FREE_SPACE_FLASHFS_REG, 0, 3, signed=False
-            )
+            available_chunks_fs = self.instrument.read_u16(self.GET_FREE_SPACE_FLASHFS_REG)
             logger.debug("Device (%s) has available space of %d chunks", device_str, available_chunks_fs)
         except minimalmodbus.ModbusException:
             logger.error("Device (%s) has too old bootloader to save user data!", device_str)

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -547,6 +547,7 @@ def _do_flash(modbus_connection, downloaded_wbfw: DownloadedWBFW, erase_settings
                 f"Bootloader downgrade (v{actual_bl_version} -> v{downloaded_wbfw.version}) is not allowed!"
             )
 
+    initial_port_settings = modbus_connection.settings
     modbus_connection.reboot_to_bootloader()
     if bl_to_flash:
         logger.debug("Performing bootloader update for %s", device_str)
@@ -559,6 +560,7 @@ def _do_flash(modbus_connection, downloaded_wbfw: DownloadedWBFW, erase_settings
         )
         downloaded_fw = download_fw_fallback(fw_signature, RELEASE_INFO, force=force)
         direct_flash(downloaded_fw, modbus_connection, erase_settings, force=force)
+    modbus_connection._set_port_settings_raw(initial_port_settings)
 
 
 def flash_alive_device(modbus_connection, mode, branch_name, specified_fw_version, force, erase_settings):
@@ -611,9 +613,7 @@ def flash_alive_device(modbus_connection, mode, branch_name, specified_fw_versio
         allow_downgrade=True,
         debug_info="(%s %d %s)" % (fw_signature, modbus_connection.slaveid, modbus_connection.port),
     ):
-        initial_port_settings = modbus_connection.settings
         _do_flash(modbus_connection, downloaded_wbfw, erase_settings, force=force)
-        modbus_connection._set_port_settings_raw(initial_port_settings)
 
 
 class DeviceInfo(namedtuple("DeviceInfo", ["name", "modbus_connection"])):

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -552,6 +552,7 @@ def _do_flash(modbus_connection, downloaded_wbfw: DownloadedWBFW, erase_settings
     )
 
     initial_port_settings = modbus_connection.settings
+    initial_response_timeout = modbus_connection.response_timeout
     modbus_connection.reboot_to_bootloader()
     if bl_to_flash:
         logger.debug("Performing bootloader update for %s", device_str)
@@ -579,6 +580,7 @@ def _do_flash(modbus_connection, downloaded_wbfw: DownloadedWBFW, erase_settings
             do_check_userdata_saving=do_check_userdata_saving,
         )
     modbus_connection._set_port_settings_raw(initial_port_settings)
+    modbus_connection.set_response_timeout(initial_response_timeout)
 
 
 def flash_alive_device(modbus_connection, mode, branch_name, specified_fw_version, force, erase_settings):

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -354,6 +354,7 @@ def direct_flash(
     erase_all_settings=False,
     erase_uart_only=False,
     force=False,
+    do_check_userdata_saving=False,
 ):
     """
     Performing operations in bootloader (device is already into):
@@ -387,8 +388,7 @@ def direct_flash(
         flasher.reset_eeprom()
 
     parsed_wbfw = fw_flasher.ParsedWBFW(fw_fpath)
-    # skip annoying question on bootloader update
-    if (len(parsed_wbfw.data_chunks) > 64) and (not flasher.is_userdata_preserved(parsed_wbfw)):
+    if do_check_userdata_saving and (not flasher.is_userdata_preserved(parsed_wbfw)):
         _ensure("User data (such as ir commands) will be erased. Are you sure? (do a backup if not!)")
     flasher.flash_in_bl(parsed_wbfw)
 
@@ -537,29 +537,47 @@ def _do_flash(modbus_connection, downloaded_wbfw: DownloadedWBFW, erase_settings
     device_str = f"{fw_signature} {modbus_connection.port}:{modbus_connection.slaveid}"
     logger.debug("Flashing approved for %s", device_str)
     bl_to_flash = None
+    actual_bl_version = modbus_connection.get_bootloader_version()
     if downloaded_wbfw.mode == MODE_FW:
         if is_bl_update_required(modbus_connection, force):
             bl_to_flash = fw_downloader.RemoteFileWatcher(MODE_BOOTLOADER).download(fw_signature, "latest")
     elif downloaded_wbfw.mode == MODE_BOOTLOADER:
-        actual_bl_version = modbus_connection.get_bootloader_version()
         if semantic_version.Version(downloaded_wbfw.version) < semantic_version.Version(actual_bl_version):
             raise UpdateDeviceError(
                 f"Bootloader downgrade (v{actual_bl_version} -> v{downloaded_wbfw.version}) is not allowed!"
             )
 
+    do_check_userdata_saving = semantic_version.Version(actual_bl_version) >= semantic_version.Version(
+        "1.2.0"
+    )
+
     initial_port_settings = modbus_connection.settings
     modbus_connection.reboot_to_bootloader()
     if bl_to_flash:
         logger.debug("Performing bootloader update for %s", device_str)
-        direct_flash(bl_to_flash, modbus_connection, force=force)
-    direct_flash(downloaded_wbfw.fpath, modbus_connection, erase_settings, force=force)
+        direct_flash(
+            bl_to_flash, modbus_connection, force=force, do_check_userdata_saving=False
+        )  # bl is relatively small in chunk-size
+    direct_flash(
+        downloaded_wbfw.fpath,
+        modbus_connection,
+        erase_settings,
+        force=force,
+        do_check_userdata_saving=do_check_userdata_saving,
+    )
 
     if downloaded_wbfw.mode == MODE_BOOTLOADER:
         logger.info(
             'Bootloader was successfully flashed. Will flash released firmware for "%s"', fw_signature
         )
         downloaded_fw = download_fw_fallback(fw_signature, RELEASE_INFO, force=force)
-        direct_flash(downloaded_fw, modbus_connection, erase_settings, force=force)
+        direct_flash(
+            downloaded_fw,
+            modbus_connection,
+            erase_settings,
+            force=force,
+            do_check_userdata_saving=do_check_userdata_saving,
+        )
     modbus_connection._set_port_settings_raw(initial_port_settings)
 
 


### PR DESCRIPTION
- при update-all на девайсах с нестандартными настройками стреляла проверка сохранения пользовательских данных. Причина - я забыл, что недавно внедрили неявную перезапись serial-настроек при переходе в бутлоадер
- дикие тормоза update-all кучи (>1) устройств (на одном всё ок; дальше - тормозит). Причина - конский response_timeout на проверке в бутлоадере устройство или нет. Работая с бутлоадером, мы крутим response_timeout, и он пролезал наружу. Хорошо видно при --debug
- @aadegtyarev потыкал свежие изменения и предложил не ругаться, если бутлоадер еще не поддерживает проверку сохранения user-данных, чтобы не ломать привычное людям поведение