### PR TITLE
Fix getting bootloader version if device in bootloader

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.10.4) stable; urgency=medium
+
+  * Fix getting bootloader virsion if device in bootloader
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 12 Mar 2024 12:40:39 +0300
+
 wb-mcu-fw-updater (1.10.3) stable; urgency=medium
 
   * Fix bootloader updating issues on custom uart params

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -728,10 +728,21 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
             raise TooOldDeviceError("Device is too old and haven't fw_signature in regs!")
 
     def get_bootloader_version(self):
+        # Try to read full-length version string. The last char is STM type or dev bootloader sign
+        try:
+            version = self.read_string(
+                self.COMMON_REGS_MAP["bootloader_version"], self.BOOTLOADER_VERSION_LENGTH
+            )
+            return version[:len(version)-1]
+        except minimalmodbus.IllegalRequestError:
+            pass
+            #raise TooOldDeviceError("Device is too old and haven't bootloader version in regs!")
+
+        # Try to read reduced version string for compatibility with old devices
         try:
             return self.read_string(
                 self.COMMON_REGS_MAP["bootloader_version"], self.BOOTLOADER_VERSION_LENGTH - 1
-            )  # The last char is STM type
+            )
         except minimalmodbus.IllegalRequestError:
             raise TooOldDeviceError("Device is too old and haven't bootloader version in regs!")
 

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -733,11 +733,11 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
             version = self.read_string(
                 self.COMMON_REGS_MAP["bootloader_version"], self.BOOTLOADER_VERSION_LENGTH
             )
-            return version[: len(version) - 1]
+            return version[:-1]
         except minimalmodbus.IllegalRequestError:
             pass
 
-        # Try to read reduced version string for compatibility with old devices
+        # Try to read reduced version string for compatibility with old devices (available only in fw)
         try:
             return self.read_string(
                 self.COMMON_REGS_MAP["bootloader_version"], self.BOOTLOADER_VERSION_LENGTH - 1

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -736,7 +736,6 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
             return version[:len(version)-1]
         except minimalmodbus.IllegalRequestError:
             pass
-            #raise TooOldDeviceError("Device is too old and haven't bootloader version in regs!")
 
         # Try to read reduced version string for compatibility with old devices
         try:

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -733,7 +733,7 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
             version = self.read_string(
                 self.COMMON_REGS_MAP["bootloader_version"], self.BOOTLOADER_VERSION_LENGTH
             )
-            return version[:len(version)-1]
+            return version[: len(version) - 1]
         except minimalmodbus.IllegalRequestError:
             pass
 


### PR DESCRIPTION
сделала фикс получения версии бутлодера. Если устройство находится в бутлодере, то старый вариант чтения 7 регистров не работает, потому что в бутлодере можно прочитать версию целиком - 8 слов.
На всякий случай сделала сначала чтение 8 слов (если успех возвращается строка кроме последнего секретного символа), если не успех, то попытка прочитать 7 слов как раньше