### PR TITLE
wb_mcu_fw_updater/update_monitor.py

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mcu-fw-updater (1.10.7) stable; urgency=medium
+
+  * Temporarily disable auto-update bootloader during fw update
+  (some users faced bl-update problems especially from v1.3 to 1.4)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Fri, 15 Mar 2024 14:54:21 +0300
+
 wb-mcu-fw-updater (1.10.6) stable; urgency=medium
 
   * add requirements.txt and pyproject.toml from codestyle repo

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -516,6 +516,9 @@ def is_interactive_shell():
 
 
 def is_bl_update_required(modbus_connection, force=False):
+    # TODO: some users faced bl-update problems (from v1.3 to 1.4) => temporarily disable auto-update bootloaders
+    return False
+
     fw_sig = modbus_connection.get_fw_signature()
     local_version = modbus_connection.get_bootloader_version()
     remote_version = fw_downloader.RemoteFileWatcher(mode=MODE_BOOTLOADER).get_latest_version_number(fw_sig)


### PR DESCRIPTION
обсудили с @nikitoz236 - решили временно отключить автообновление бутлоадеров, пока ембеддеры не разберутся, почему устройства кирпичатся и не починят