### PR TITLE
update-all: trying to update only polling-enabled in (wb-mqtt-serial.…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.10.8) stable; urgency=medium
+
+  * update-all: trying to update only polling-enabled in (wb-mqtt-serial.conf) devices
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Thu, 21 Mar 2024 12:21:48 +0300
+
 wb-mcu-fw-updater (1.10.7) stable; urgency=medium
 
   * Temporarily disable auto-update bootloader during fw update

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -307,6 +307,8 @@ def get_devices_on_driver(driver_config_fname):  # TODO: move to separate module
             port_response_timeout = int(port.get("response_timeout_ms", 0)) * 1e-3
             devices_on_port = set()
             for serial_device in port.get("devices", []):
+                if not serial_device.get("enabled", True):
+                    continue
                 device_name = serial_device.get("device_type", "Unknown")
                 slaveid = serial_device["slave_id"]
                 device_response_timeout = int(serial_device.get("response_timeout_ms", 0)) * 1e-3


### PR DESCRIPTION
…conf) devices


если снять эту галочку - update-all не будет стучаться в девайс
![image](https://github.com/wirenboard/wb-mcu-fw-updater/assets/25829054/38f3a1d5-1797-4081-8938-591221eb9ffa)
