### PR TITLE
bindings: fix bootloader version parsing

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.10.10) stable; urgency=medium
+
+  * bindings: fix bootloader version parsing
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 27 Mar 2024 17:12:54 +0300
+
 wb-mcu-fw-updater (1.10.9) stable; urgency=medium
 
   * update-all: trying to update only polling-enabled in (wb-mqtt-serial.conf) devices

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -485,9 +485,7 @@ class MinimalModbusAPIWrapper(object):
             order = minimalmodbus.BYTEORDER_LITTLE
         self.device.write_long(addr, value, signed=True, byteorder=order)
 
-    @apply_serial_settings
-    @force()
-    def read_string(self, addr, regs_lenght):
+    def _to_wb_str(self, modbus_bytestr):
         """
         Reading a row of consecutive uint16 holding registers and interpreting row as a string.
         Wiren Board devices store a placeholder + char per one u16 reg (ex: '\x00A1' or '\xFFA1' in some roms)
@@ -500,12 +498,17 @@ class MinimalModbusAPIWrapper(object):
         :rtype: str
         """
         empty_chars_placeholders = ("00", "FF", " ")
-        ret = minimalmodbus._hexlify(self.device.read_string(addr, regs_lenght, 3))
+        ret = minimalmodbus._hexlify(modbus_bytestr)
         for placeholder in empty_chars_placeholders:  # Clearing a string to only meaningful bytes
             ret = ret.replace(placeholder, "")  # 'A1B2C3' bytes-only string
         return str(
             unhexlify(ret).decode(encoding="utf-8", errors="ignore")
         ).strip()  # TODO: "backslashreplace" when drop py2
+
+    @apply_serial_settings
+    @force()
+    def read_string(self, addr, regs_lenght):
+        return self._to_wb_str(self.device.read_string(addr, regs_lenght, 3))
 
 
 def auto_find_uart_settings(method_to_decorate):
@@ -732,21 +735,25 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
         except minimalmodbus.IllegalRequestError:
             raise TooOldDeviceError("Device is too old and haven't fw_signature in regs!")
 
+    @apply_serial_settings
+    @force()
     def get_bootloader_version(self):
         # Try to read full-length version string. The last char is STM type or dev bootloader sign
         try:
-            version = self.read_string(
-                self.COMMON_REGS_MAP["bootloader_version"], self.BOOTLOADER_VERSION_LENGTH
+            version = self.device.read_string(
+                self.COMMON_REGS_MAP["bootloader_version"], self.BOOTLOADER_VERSION_LENGTH, 3
             )
-            return version[:-1]
+            ret = version[:-1]  # strip bootloader type marker from raw bytes
+            return self._to_wb_str(ret)
         except minimalmodbus.IllegalRequestError:
             pass
 
         # Try to read reduced version string for compatibility with old devices (available only in fw)
         try:
-            return self.read_string(
-                self.COMMON_REGS_MAP["bootloader_version"], self.BOOTLOADER_VERSION_LENGTH - 1
+            ret = self.device.read_string(
+                self.COMMON_REGS_MAP["bootloader_version"], self.BOOTLOADER_VERSION_LENGTH - 1, 3
             )
+            return self._to_wb_str(ret)
         except minimalmodbus.IllegalRequestError:
             raise TooOldDeviceError("Device is too old and haven't bootloader version in regs!")
 


### PR DESCRIPTION
неправильно обрезали служебный символ в версии бутлоадера; теперь - правильно!

клиентов это никак не затрагивало (из-за логики самого упдатера; стреляло только в tsng)

![image](https://github.com/wirenboard/wb-mcu-fw-updater/assets/25829054/fdf7bb7a-6e9c-4410-8446-5a068cf6922a)
работает и в бутлоадере, и не в бутлоадере; обновляется - не стреляет