### PR TITLE
bindings: fix serial settings around set_slave_addr

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.10.10) stable; urgency=medium
+
+  * bindings: fix serial settings around set_slave_addr
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Wed, 27 Mar 2024 17:15:34 +0300
+
 wb-mcu-fw-updater (1.10.9) stable; urgency=medium
 
   * update-all: trying to update only polling-enabled in (wb-mqtt-serial.conf) devices

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -660,9 +660,9 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
         except minimalmodbus.ModbusException:
             pass
         baudrate, parity, stopbits = (
-            self.settings["baudrate"],
-            self.settings["parity"],
-            self.settings["stopbits"],
+            self.settings.baudrate,
+            self.settings.parity,
+            self.settings.stopbits,
         )
         checking_device = MinimalModbusAPIWrapper(
             to_write, self.port, baudrate, parity, stopbits, self.instrument
@@ -905,5 +905,5 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
         ):
             _validate_param(param, allowed_row)
         self._write_port_settings(baudrate, ALLOWED_PARITIES[parity], stopbits)
-        new_port_settings = {"baudrate": baudrate, "parity": parity, "stopbits": stopbits}
+        new_port_settings = SerialSettings(baudrate=baudrate, parity=parity, stopbits=stopbits)
         self._set_port_settings_raw(new_port_settings)


### PR DESCRIPTION
не заметил, когда потроха перетряхивал
в упдатере не стреляет; выстрелило в tsng