### PR TITLE
update-bl: print bootloader version in "latest" case

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.10.12) stable; urgency=medium
+
+  * update-bl: print bootloader version in "latest" case
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 02 Mar 2024 18:45:32 +0300
+
 wb-mcu-fw-updater (1.10.11) stable; urgency=medium
 
   * bindings: fix bootloader version parsing

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -72,11 +72,9 @@ def _update_alive_device(
             logger.debug("Trying to acquire fw-signature...")
             fw_sig = update_monitor._restore_fw_signature(modbus_connection)
             if fw_sig:
-                downloaded_wbfw = update_monitor._do_download(
-                    fw_sig, version, branch, mode, retrieve_latest_vnum=False
-                )  # we don't need any update-check here
+                downloaded_wbfw = update_monitor._do_download(fw_sig, version, branch, mode)
                 logger.info(
-                    "Will flash %s v%s to bring %s %s alive",
+                    "Will flash %s v:%s to bring %s %s alive",
                     mode,
                     downloaded_wbfw.version,
                     fw_sig,

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -68,7 +68,12 @@ def _update_alive_device(
 
     try:
         if is_in_bootloader:
-            logger.info("Device %s supposed to be alive, but found in bootloader", device_str)
+            try:
+                bl_version = modbus_connection.get_bootloader_version()
+            except ModbusException:
+                logger.exception("Failed to read bootloader version")
+                bl_version = ""
+            logger.info("Device %s supposed to be alive, but found in bootloader %s", device_str, bl_version)
             logger.debug("Trying to acquire fw-signature...")
             fw_sig = update_monitor._restore_fw_signature(modbus_connection)
             if fw_sig:

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -514,7 +514,7 @@ def _do_download(fw_sig, version, branch, mode, retrieve_latest_vnum=True):
             downloaded_fw = downloader.download(fw_sig, version)
         if mode_name == "bootloader":
             retrieve_latest_vnum = False
-            # TODO: put unstable_bl version to latest.txt on ci; then remove "retrieve_latest_vnum" logic (task 51352)
+            # TODO: clear bootloader branches from s3 (or wait some time) and remove "retrieve_latest_vnum" logic
 
     if version == "release":  # triggered updating from releases
         version, released_fw_endpoint = get_released_fw(fw_sig, RELEASE_INFO)


### PR DESCRIPTION
@pgasheev заметил, что при воскрешении девайса, update-bl не пишет версию бутлоадера (как текущую, так и прошиваемую) => теперь пишет
https://support.wirenboard.com/t/wb-m1w2-v2-obnovlenie-do-4-32-2-otvalilis-ds18b20/18447/99

было
![image](https://github.com/wirenboard/wb-mcu-fw-updater/assets/25829054/11f48e37-de1a-49be-8887-7307ae31eaf0)

стало
![image](https://github.com/wirenboard/wb-mcu-fw-updater/assets/25829054/58250232-03ca-47d0-bddf-aa4e20ffab20)




retrieve_latest_vnum - многолетний костыль, внедренный из-за того, что господа эмбеддеры изначально забыли класть latest.txt для сборок бутлоадеров из веток => я залез к ним в систему сборки и добавил, но убирать эту логику из упдатера - пока рановато (старые ветки остались на fw-releases)