### PR TITLE
Feature/auto update unstable bl

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.11.1) stable; urgency=medium
+
+  * Update bootloader anyway, if local version not found on remote
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Tue, 11 Jun 2024 13:57:02 +0300
+
 wb-mcu-fw-updater (1.11.0) stable; urgency=medium
 
   * reduce modbus retries from 5 to 2

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -147,6 +147,19 @@ class RemoteFileWatcher(object):
         url_path = urllib.parse.urljoin(CONFIG["ROOT_URL"], remote_path)
         return read_remote_file(url_path)
 
+    def is_version_exist(self, fwsig: str, version: str):
+        """
+        Check, does specified fw/bl version exist for actual fw_sig.
+        In some cases, buggy fws could be removed from fw-releases.
+        """
+        remote_path = self._join(self.parent_url_path % fwsig, f"{version}{CONFIG['FW_EXTENSION']}")
+        url_path = urllib.parse.urljoin(CONFIG["ROOT_URL"], remote_path)
+        try:
+            get_request(url_path)
+            return True
+        except WBRemoteStorageError:
+            return False
+
     def download(self, name, version="latest"):
         """
         Downloading a firmware/bootloader file with specified version to specified fname.

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -577,11 +577,23 @@ def is_interactive_shell():
 def is_bl_update_required(modbus_connection, force=False):
     fw_sig = modbus_connection.get_fw_signature()
     local_version = modbus_connection.get_bootloader_version()
-    remote_version = fw_downloader.RemoteFileWatcher(mode=MODE_BOOTLOADER).get_latest_version_number(fw_sig)
-    if semantic_version.Version(local_version) == semantic_version.Version(remote_version):
+    remote_file_watcher = fw_downloader.RemoteFileWatcher(mode=MODE_BOOTLOADER)
+    latest_remote_version = remote_file_watcher.get_latest_version_number(fw_sig)
+
+    if semantic_version.Version(local_version) == semantic_version.Version(latest_remote_version):
         return False
+
+    if not remote_file_watcher.is_version_exist(fw_sig, local_version):
+        logger.warning(
+            "Local bootloader version v%s is not found on remote! (maybe was removed manually) => "
+            "Will update bootloader to latest v%s anyway!",
+            local_version,
+            latest_remote_version,
+        )
+        return True
+
     suggestion_str = (
-        f"Bootloader update (v{local_version} -> v{remote_version}) for {fw_sig} "
+        f"Bootloader update (v{local_version} -> v{latest_remote_version}) for {fw_sig} "
         f"{modbus_connection.port}:{modbus_connection.slaveid} is available! "
         "(bootloader updates are highly recommended to install)"
     )


### PR DESCRIPTION
как-то так иногда получается, что забагованный бутлоадер попадает на устройства и на fw-releases

=> поговорили с @nikitoz236 - сделали логику "если текущей версии бутлоадера нет на s3 (увидели лажу и удалили руками) - обновляем бутлоадер без разговоров"

на картинке - подхакал чтение версии бутлоадера (таких удалённых бутлоадеров пока нет)
![image](https://github.com/wirenboard/wb-mcu-fw-updater/assets/25829054/cb9dd7b2-3efd-4f0a-9ecf-926d5253fa35)
