### PR TITLE
Handle modbus exceptions

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.11.1) stable; urgency=medium
+
+  * Handle modbus exceptions
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 02 Sep 2024 15:10:00 +0400
+
 wb-mcu-fw-updater (1.11.0) stable; urgency=medium
 
   * reduce modbus retries from 5 to 2

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -211,7 +211,7 @@ def update_all(args):
             allow_downgrade=args.allow_downgrade,
             instrument=args.instrument,
         )
-    except update_monitor.ConfigParsingError as e:
+    except (update_monitor.ConfigParsingError, ModbusException) as e:
         die(e)
 
 
@@ -226,7 +226,7 @@ def recover_all(args):
             force=args.force,
             instrument=args.instrument,
         )
-    except update_monitor.ConfigParsingError as e:
+    except (update_monitor.ConfigParsingError, ModbusException) as e:
         die(e)
 
 


### PR DESCRIPTION
Before:
```sh
$ wb-mcu-fw-updater update-all
2024-09-02 16:49:13,500 Will probe all devices on enabled serial ports of /etc/wb-mqtt-serial.conf:
Probing WB-MSW v.3 (port: /dev/ttyRS485-1, slaveid: 31, uart_params: 9600N2, response_timeout: 0.50)... (elapsed: 00:00)
2024-09-02 16:49:13,981 Unhandled exception!
Traceback (most recent call last):
  File "/usr/bin/wb-mcu-fw-updater", line 529, in <module>
    args.func(args)
  File "/usr/bin/wb-mcu-fw-updater", line 208, in update_all
    update_monitor._update_all(
  File "/usr/lib/python3/dist-packages/wb_mcu_fw_updater/update_monitor.py", line 795, in _update_all
    probing_result = probe_all_devices(
  File "/usr/lib/python3/dist-packages/wb_mcu_fw_updater/update_monitor.py", line 750, in probe_all_devices
    modbus_connection=get_correct_modbus_connection(
  File "/usr/lib/python3/dist-packages/wb_mcu_fw_updater/update_monitor.py", line 310, in get_correct_modbus_connection
    check_device_is_a_wb_one(modbus_connection)
  File "/usr/lib/python3/dist-packages/wb_mcu_fw_updater/update_monitor.py", line 262, in check_device_is_a_wb_one
    sn = modbus_connection.get_serial_number()  # Will raise NoResponseError, if disconnected
  File "/usr/lib/python3/dist-packages/wb_modbus/bindings.py", line 631, in get_serial_number
    device_signature = str(self.get_device_signature())
  File "/usr/lib/python3/dist-packages/wb_modbus/bindings.py", line 724, in get_device_signature
    return self.read_string(self.COMMON_REGS_MAP["device_signature"], self.DEVICE_SIGNATURE_LENGTH)
  File "/usr/lib/python3/dist-packages/wb_modbus/bindings.py", line 45, in wrapper
    return f(self, *args, **kwargs)
  File "/usr/lib/python3/dist-packages/wb_modbus/bindings.py", line 72, in wrapper
    raise thrown_exc
  File "/usr/lib/python3/dist-packages/wb_modbus/bindings.py", line 66, in wrapper
    return f(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/wb_modbus/bindings.py", line 511, in read_string
    return self._to_wb_str(self.device.read_string(addr, regs_lenght, 3))
  File "/usr/lib/python3/dist-packages/wb_modbus/minimalmodbus.py", line 743, in read_string
    return self._generic_command(
  File "/usr/lib/python3/dist-packages/wb_modbus/minimalmodbus.py", line 1139, in _generic_command
    payload_from_slave = self._perform_command(functioncode, payload_to_slave)
  File "/usr/lib/python3/dist-packages/wb_modbus/minimalmodbus.py", line 1206, in _perform_command
    payload_from_slave = _extract_payload(response, self.address, self.mode, functioncode)
  File "/usr/lib/python3/dist-packages/wb_modbus/minimalmodbus.py", line 1689, in _extract_payload
    raise InvalidResponseError(text)
wb_modbus.minimalmodbus.InvalidResponseError: Checksum error in rtu mode: 'Öd' instead of 'Öc' . The response is: '\x1f\x03\x0c\x00W\x00B\x00M\x00S\x00W\x003Öc' (plain response: '\x1f\x03\x0c\x00W\x00B\x00M\x00S\x00W\x003Öc')
```

After:
```sh
$ wb-mcu-fw-updater update-all
2024-09-02 16:40:40,115 Will probe all devices on enabled serial ports of /etc/wb-mqtt-serial.conf:
Probing WB-MSW v.3 (port: /dev/ttyRS485-1, slaveid: 31, uart_params: 9600N2, response_timeout: 0.50)... (elapsed: 00:00)
2024-09-02 16:40:40,617 Checksum error in rtu mode: 'Öd' instead of 'Öc' . The response is: '\x1f\x03\x0c\x00W\x00B\x00M\x00S\x00W\x003Öc' (plain response: '\x1f\x03\x0c\x00W\x00B\x00M\x00S\x00W\x003Öc')
```