### PR TITLE
update-all: fix modbus CRC errors

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,11 @@
 wb-mcu-fw-updater (1.11.1) stable; urgency=medium
 
+  * update-all: fix modbus CRC errors
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 06 Sep 2024 14:00:00 +0400
+
+wb-mcu-fw-updater (1.11.1) stable; urgency=medium
+
   * Handle modbus exceptions
 
  -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Mon, 02 Sep 2024 15:10:00 +0400

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-wb-mcu-fw-updater (1.11.1) stable; urgency=medium
+wb-mcu-fw-updater (1.11.2) stable; urgency=medium
 
   * update-all: fix modbus CRC errors
 

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import termios
 import threading
+import time
 import urllib.parse
 from collections import defaultdict, namedtuple
 from contextlib import contextmanager
@@ -65,7 +66,7 @@ SkipUpdateReason = enum.Enum(value="SkipUpdateReason", names=("is_actual", "gone
 
 
 @contextmanager
-def spinner(estimated_time_s=float("+inf"), tdelta_s=1, description="", tqdm_kwargs={}):
+def spinner(estimated_time_s=float("+inf"), tdelta_s=0.1, description="", tqdm_kwargs={}):
     if description:
         logger.debug(description)
         tqdm_kwargs.update({"desc": description})
@@ -76,6 +77,7 @@ def spinner(estimated_time_s=float("+inf"), tdelta_s=1, description="", tqdm_kwa
     def pbar_update_runner(pbar, interval, stop_event):
         while not stop_event.is_set():
             pbar.update(interval)
+            time.sleep(interval)
 
     pbar_update_thread = threading.Thread(target=pbar_update_runner, args=(pbar, tdelta_s, stop_event))
     pbar_update_thread.start()


### PR DESCRIPTION
Минимальный пример для воспроизведения:
```python
import threading

from wb_modbus.bindings import WBModbusDeviceBase
from wb_modbus.instruments import StopbitsTolerantInstrument

def worker():
    while True:
        v = 1

t = threading.Thread(target=worker)
t.start()

c = WBModbusDeviceBase(31, "/dev/ttyRS485-1", baudrate=38400, instrument=StopbitsTolerantInstrument)
c.get_fw_signature()
```

Тред с циклом начинает потреблять 100% cpu, а в основном потоке при чтении из порта иногда теряются байтики. (GIL + тайминг?) Погонял с фиксом, больше не стреляет, потребление cpu в норме.