### PR TITLE
Fix StopbitsTolerantInstrument read/write

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ debian/*.debhelper.log
 debian/*.substvars
 debian/*.debhelper
 debian/files
+.venv

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.11.4) stable; urgency=medium
+
+  * Fix MSW 4.31.10 flashing fail
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 28 Oct 2024 10:12:52 +0300
+
 wb-mcu-fw-updater (1.11.3) stable; urgency=medium
 
   * Update bootloader anyway, if local version not found on remote

--- a/wb_mcu_fw_updater/fw_flasher.py
+++ b/wb_mcu_fw_updater/fw_flasher.py
@@ -110,10 +110,16 @@ class ModbusInBlFlasher(object):
         instrument=StopbitsTolerantInstrument,
     ):
         self.instrument = bindings.WBModbusDeviceBase(
-            addr, port, bd, parity, stopbits, instrument=instrument, foregoing_noise_cancelling=True
+            addr,
+            port,
+            bd,
+            parity,
+            stopbits,
+            response_timeout=response_timeout,
+            instrument=instrument,
+            foregoing_noise_cancelling=True,
         )
         self._actual_response_timeout = response_timeout
-        self.instrument.set_response_timeout(self._actual_response_timeout)
 
     def _send_info(self, regs_row):
         """


### PR DESCRIPTION
Можно попробовать вот тут https://wirenboard.cloud/organizations/ebd1a3f3-5870-4572-8072-8261d94b334c/controllers/ATY5YNRK  (Надо попинговать Андрея Породнова перед тестом, чтобы он точно включил контроллер и девайсы)
Есть тейлскейл на этот контроллер. Датчики мсв 4 висят на первом порту с адресами 27 и 149. Сейчас уже накачен фикс, но можно откатиться, чтобы проверить что оно вобще ломается. Проверяйте на 149 девайсе, иногда оно не с первого раза падало. 27 реже ломался
Как я понимаю, проблема была гдето вокруг механизма смены стопбитов на лету. Сначала убрала использование приватных методов, стало лучше. Потом вобще решила не трогать операцию чтения, а смену стопбитов делать только до и после записи: 10 раз из 10 прошилось хорошо, что из бл, что из прошивки.
Немного изменила задание таймаута (см изменения), потому что оно сначала инициализировалось значением по умолчанию и потом отдельно значением из параметров, подправила работает.