### PR TITLE
instruments: rework StopbitsTolerantInstrument (more strictly wait fo…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mcu-fw-updater (1.11.4) stable; urgency=medium
+
+  * instruments: rework StopbitsTolerantInstrument (more strictly wait for outgoing data);
+  fixes faulty updates of some new devices (msw5G)
+
+ -- Vladimir Romanov <v.romanov@wirenboard.ru>  Mon, 28 Oct 2024 17:20:21 +0300
+
 wb-mcu-fw-updater (1.11.3) stable; urgency=medium
 
   * Update bootloader anyway, if local version not found on remote

--- a/wb_modbus/instruments.py
+++ b/wb_modbus/instruments.py
@@ -1,5 +1,6 @@
 import atexit
 import ipaddress
+import os
 import sys
 import termios
 import time
@@ -232,9 +233,19 @@ class StopbitsTolerantInstrument(PyserialBackendInstrument):
     Setting stopbits to 1 between sending request and receiving response.
     """
 
+    def __init__(self, *args, **kwargs):
+        super(StopbitsTolerantInstrument, self).__init__(*args, **kwargs)
+        if os.name != "posix":
+            raise RuntimeError("Stopbits-tolerance is supported only in posix")
+
     def _set_stopbits_onthefly(self, stopbits):
         self.serial._stopbits = stopbits
-        self.serial._reconfigure_port()
+        flags = termios.tcgetattr(self.serial.fd)
+        if stopbits == 1:
+            flags[3] = flags[3] & ~termios.CSTOPB
+        else:  # 2sb
+            flags[3] = flags[3] | termios.CSTOPB
+        termios.tcsetattr(self.serial.fd, termios.TCSADRAIN, flags)
 
     def _write_to_bus(self, request):
         """
@@ -242,18 +253,6 @@ class StopbitsTolerantInstrument(PyserialBackendInstrument):
         """
         self._initial_stopbits = self.serial._stopbits
         super(StopbitsTolerantInstrument, self)._write_to_bus(request)
-        write_ts = time.time()
-        while (self.serial.out_waiting > 0) or (self.serial.in_waiting == 0):
-            if time.time() - write_ts < self.serial.timeout:
-                time.sleep(0.1)
-            else:
-                if (self.serial.out_waiting == 0) and (self.serial.in_waiting == 0):
-                    raise minimalmodbus.NoResponseError("No communication with the instrument (no answer)")
-                else:
-                    raise minimalmodbus.MasterReportedException(
-                        "Output serial buffer is not empty after %.2fs (serial.timeout)" % self.serial.timeout
-                    )
-        termios.tcdrain(self.serial.fd)  # ensuring, all buffered data has transmitted
         self._set_stopbits_onthefly(stopbits=1)
 
     def _read_from_bus(self, number_of_bytes_to_read, minimum_silent_period):


### PR DESCRIPTION
…r outgoing data); fixes faulty updates of some new devices (msw5G)

некоторые девайсы (msw5G, например) что-то стали плохо обновляться упдатером. @ekateluv раскопала, что:
1) виноват только упдатер (serial-tool, flasher, остальное - нормально работают)
2) упдатер теряет байтик **посреди** посылки (с ожидаемой верной crc!!!) -> виновата наша какая-то злая магия
3) упдатер с дефолтным minimalmodbus-инструментом работает нормально

=> собака порылась где-то около колдовства с stopbit-tolerance

я туда думал-смотрел и заметил, что всё работает с `strace wb-mcu-fw-updater давай-обновляй` и не работает без strace впереди

=> гипотеза - наши костыли вокруг определения-конца-передачи дала сбой (а мб и не работала нормально никогда). Гипотеза и подтвердилась (всё работает с увеличенным таймаутом посередине, например) => сделал хорошо, на системных вызовах; @ekateluv гоняет там, где воспроизводится