### PR TITLE
Fix typo in branch name for fw source

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.11.6) stable; urgency=medium
+
+  * Fix typo in branch name for fw source
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 18 Nov 2024 14:31:08 +0300
+
 wb-mcu-fw-updater (1.11.5) stable; urgency=medium
 
   * Enable angry pylint. No fuctional changes

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -131,7 +131,7 @@ class RemoteFileWatcher:
         :type branch_name: str, optional
         """
         self.mode = mode
-        fw_source = f'unstable/{branch_name if branch_name else CONFIG["DEFAULT_SOURCE"]}'
+        fw_source = f"unstable/{branch_name}" if branch_name else CONFIG["DEFAULT_SOURCE"]
         self.parent_url_path = self._join(self.mode, sort_by, "%s", fw_source)  # fw_sig or device_sig
 
     def _join(self, *args):


### PR DESCRIPTION
Ошибочка после рефакторинга для пайлинта. Было вот так
 fw_source = "unstable/%s" % branch_name if branch_name else CONFIG["DEFAULT_SOURCE"]