### PR TITLE
Fix warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,4 @@
 buildDebArchAll defaultRunPythonChecks: true,
+                defaultRunLintian: true,
                 defaultAngryPylint: true,
                 repos: ['release', 'devTools']

--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@ A command-line tool, updating WirenBoard modbus devices to latest firmwares. Ver
 * wb_modbus - safe & configurable wrappers around minimalmodbus; common (for Wiren Board devices) modbus bindings.
 
 ## Debian packages:
-* python2-wb-mcu-fw-updater - python2 library (wb_mcu_fw_updater + wb_modbus)
 * python3-wb-mcu-fw-updater - python3 library (wb_mcu_fw_updater + wb_modbus)
 * wb-mcu-fw-updater - python3-library-dependent binary
 
 ## External dependencies:
-* for python2-package: python-serial
 * for python3-package: python3-serial
 
 ## Building:

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.12.1) stable; urgency=medium
+
+  * Fix warnings
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 18 Apr 2025 14:30:00 +0400
+
 wb-mcu-fw-updater (1.12.0) stable; urgency=medium
 
   * Disable stop bit tolerant during flashing

--- a/debian/control
+++ b/debian/control
@@ -1,20 +1,22 @@
 Source: wb-mcu-fw-updater
-Maintainer: Vladimir Romanov <v.romanov@wirenboard.ru>
+Maintainer: Wiren Board team <info@wirenboard.com>
 Section: python
 Priority: optional
-XS-Python-Version: >= 3.9.1
+XS-Python-Version: >= 3.9
 Build-Depends: dh-python, debhelper (>= 10), python3, python3-setuptools
-Standards-Version: 3.9.1
+Standards-Version: 4.5.1
 Homepage: https://github.com/wirenboard/wb-mcu-fw-updater
-X-Python-Version: >= 3.9.1
+X-Python-Version: >= 3.9
 
 Package: python3-wb-mcu-fw-updater
 Architecture: all
-Depends: python3, ${misc:Depends}, python3-serial, python3-yaml, python3-tqdm, python3-six, python3-semantic-version, python3-wb-common (>= 2.1.0), python3-mqttrpc (>= 1.1.2), psmisc
+Depends: ${python3:Depends}, ${misc:Depends}, python3-serial, python3-yaml, python3-tqdm, python3-six, python3-semantic-version, python3-wb-common (>= 2.1.0), python3-mqttrpc (>= 1.1.2), psmisc
 Recommends: wb-mqtt-serial (>= 2.73.0)
 Description: Wiren Board modbus devices firmware update and modbus bindings python libraries (python 3)
+ Python3 library (wb_mcu_fw_updater + wb_modbus).
 
 Package: wb-mcu-fw-updater
 Architecture: all
-Depends: ${misc:Depends}, python3-wb-mcu-fw-updater (= ${binary:Version}), wb-release-info
+Depends: ${python3:Depends}, ${misc:Depends}, python3-wb-mcu-fw-updater (= ${binary:Version}), wb-release-info
 Description: Wiren Board modbus devices firmware update tool (python 3)
+ A command-line tool, updating WirenBoard modbus devices to latest firmwares.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 
 def get_version():
     with open("debian/changelog", "r", encoding="utf-8") as f:
-        return f.readline().split()[1][1:-1]
+        return f.readline().split()[1][1:-1].split("~")[0]
 
 
 setup(

--- a/wb_modbus/__init__.py
+++ b/wb_modbus/__init__.py
@@ -17,7 +17,7 @@ ALLOWED_PARITIES = OrderedDict([("N", 0), ("O", 1), ("E", 2)])
 DEBUG = False
 
 
-WBMAP_MARKER = re.compile("\S*MAP\d+\S*")  # *MAP%d* matches
+WBMAP_MARKER = re.compile(r"\S*MAP\d+\S*")  # *MAP%d* matches
 
 
 class SettingsParsingError(Exception):
@@ -31,7 +31,7 @@ def parse_uart_settings_str(settings_str):
     :return: [baudrate, parity, stopbits]
     :rtype: list
     """
-    if re.match("\d*[A-Z]\d*", settings_str):
+    if re.match(r"\d*[A-Z]\d*", settings_str):
         baudrate, stopbits = re.split("[A-Z]", settings_str)
         parity = settings_str.replace(baudrate, "").replace(stopbits, "").strip()
         if (


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* Fix warnings:
```sh
Setting up python3-wb-mcu-fw-updater (1.12.0) ...
/usr/lib/python3/dist-packages/wb_modbus/__init__.py:20: SyntaxWarning: invalid escape sequence '\S'
  WBMAP_MARKER = re.compile("\S*MAP\d+\S*")  # *MAP%d* matches
/usr/lib/python3/dist-packages/wb_modbus/__init__.py:34: SyntaxWarning: invalid escape sequence '\d'
  if re.match("\d*[A-Z]\d*", settings_str):
```
* Adopt PEP 440 (https://github.com/wirenboard/codestyle/pull/88)
* Enable lintian

___________________________________
**Что поменялось для пользователей:**
Nothing.

___________________________________
**Как проверял/а:**


