### PR TITLE
Add component signature argument

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.14.2) stable; urgency=medium
+
+  * Add component signature argument for updating components to version/branch 
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 01 Sep 2025 14:02:06 +0300
+
 wb-mcu-fw-updater (1.14.1) stable; urgency=medium
 
   * Fix log level

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -453,6 +453,7 @@ def parse_args():  # pylint:disable=inconsistent-return-statements
         "--cmp-sig",
         dest="component_signature",
         type=str,
+        metavar="<component_signature>",
         default=None,
         help="Specify the signature of the component to update in case of branch or version specified.",
     )

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -52,6 +52,7 @@ def _update_alive_device(  # pylint:disable=too-many-arguments,too-many-locals
     version,
     force,
     erase_settings,
+    component_signature,
     instrument=StopbitsTolerantInstrument,
 ):
     check_internet_connection()
@@ -106,7 +107,7 @@ def _update_alive_device(  # pylint:disable=too-many-arguments,too-many-locals
                     update_monitor.recover_device_iteration(fw_sig, modbus_connection, force)
                 else:
                     update_monitor.flash_alive_device_components(
-                        modbus_connection, mode, branch, version, force
+                        modbus_connection, mode, branch, version, force, component_signature
                     )
             else:
                 logger.error("Could not find fw-signature for %s", device_str)
@@ -119,7 +120,9 @@ def _update_alive_device(  # pylint:disable=too-many-arguments,too-many-locals
                     modbus_connection, mode, branch, version, force, erase_settings
                 )
             if mode != MODE_BOOTLOADER:  # do not update components in update-bl
-                update_monitor.flash_alive_device_components(modbus_connection, mode, branch, version, force)
+                update_monitor.flash_alive_device_components(
+                    modbus_connection, mode, branch, version, force, component_signature
+                )
             logger.info("%s", user_log.colorize("Done", "GREEN"))
     except (
         TooOldDeviceError,
@@ -147,6 +150,7 @@ def update_fw(args):  # pylint:disable=redefined-outer-name
         force=args.force,
         erase_settings=args.erase_settings,
         instrument=args.instrument,
+        component_signature="",
     )
 
 
@@ -163,6 +167,7 @@ def update_bootloader(args):  # pylint:disable=redefined-outer-name
         force=args.force,
         erase_settings=False,
         instrument=args.instrument,
+        component_signature="",
     )
 
 
@@ -179,6 +184,7 @@ def update_components(args):  # pylint:disable=redefined-outer-name
         force=args.force,
         erase_settings=False,
         instrument=args.instrument,
+        component_signature=args.component_signature,
     )
 
 
@@ -443,6 +449,13 @@ def parse_args():  # pylint:disable=inconsistent-return-statements
     add_common_logic_args(update_components_parser)
     add_modbus_connection_args(update_components_parser)
     add_fw_source_args(update_components_parser)
+    update_components_parser.add_argument(
+        "--cmp-sig",
+        dest="component_signature",
+        type=str,
+        default=None,
+        help="Specify the signature of the component to update in case of branch or version specified.",
+    )
     update_components_parser.set_defaults(func=update_components)
 
     # Flash single device, stuck in the bootloader

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -755,18 +755,17 @@ def flash_alive_device(  # pylint:disable=too-many-arguments
 
 
 def flash_alive_device_components(  # pylint:disable=too-many-arguments
-    modbus_connection, mode, branch_name, specified_fw_version, force
+    modbus_connection, mode, branch_name, specified_fw_version, force, component_signature=None
 ):
     fw_signature = modbus_connection.get_fw_signature()
     component_str = f"({fw_signature} {modbus_connection.slaveid} on {modbus_connection.port})"
-
-    if mode != MODE_COMPONENTS and (specified_fw_version not in ["latest", "release"] or branch_name):
-        logger.debug(
+    branch_or_version_specified = specified_fw_version not in ["latest", "release"] or branch_name
+    if mode != MODE_COMPONENTS and branch_or_version_specified:
+        logger.info(
             "Skip components update, due to branch is specified (%s) or "
-            "fw version is not latest/release (%s), mode: %s",
+            "fw version is not latest/release (%s)",
             branch_name,
             specified_fw_version,
-            mode,
         )
         return
     if not wait_for_wake_up(modbus_connection, timeout=2):
@@ -779,11 +778,30 @@ def flash_alive_device_components(  # pylint:disable=too-many-arguments
     if len(components_list) == 0:
         logger.info("No components available")
         return
+    if branch_or_version_specified and not component_signature:
+        logger.error("Specify the signature of the component to update to the specified version or branch")
+        return
 
     logger.info("Check updates for components %s", component_str)
-    downloaded_firmwares = []
+    components_info = []
     for component_number in components_list:
-        info = modbus_connection.get_component_info(component_number)
+        components_info.append(modbus_connection.get_component_info(component_number))
+
+    if branch_or_version_specified:
+        specified_component = next(
+            (info for info in components_info if info["signature"] == component_signature), None
+        )
+        if not specified_component:
+            logger.error(
+                "Component with signature %s not found, available signatures: %s",
+                component_signature,
+                ",".join([info["signature"] for info in components_info]),
+            )
+            return
+        components_info = [specified_component]
+
+    downloaded_firmwares = []
+    for info in components_info:
         compfw = _do_download(info["signature"], specified_fw_version, branch_name, mode=MODE_COMPONENTS)
         if not is_reflash_component_necessary(info["fw_version"], compfw.version, force, info["signature"]):
             continue

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -754,7 +754,7 @@ def flash_alive_device(  # pylint:disable=too-many-arguments
         _do_flash(modbus_connection, downloaded_wbfw, erase_settings, force=force)
 
 
-def flash_alive_device_components(  # pylint:disable=too-many-arguments
+def flash_alive_device_components(  # pylint:disable=too-many-arguments, too-many-locals, too-many-return-statements
     modbus_connection, mode, branch_name, specified_fw_version, force, component_signature=None
 ):
     fw_signature = modbus_connection.get_fw_signature()


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

При обновлении компонентов через udate-cmp можно указывать ветку и версию. По хорошему надо еще указывать сигнатуру компонента, который мы хотим прошить вот этой прошивкой из ветки/версии, чтобы оно не все подряд так прошивало 
___________________________________
**Что поменялось для пользователей:**

Updater не будет прошивать все подряд компоненты, если указана ветка или версия
___________________________________
**Как проверял/а:**

На стенде co2 на 6 этаже
https://wirenboard.youtrack.cloud/issue/SOFT-5912/Sdelat-ukazanie-signatury-komponenta-pri-obnovlenii-update-cmp
