### PR TITLE
Read fast modbus device model

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.14.3) stable; urgency=medium
+
+  * Add extended device model reading for fast modbus devices
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 22 Sep 2025 18:10:58 +0300
+
 wb-mcu-fw-updater (1.14.2) stable; urgency=medium
 
   * Add component signature argument for updating components to version/branch 

--- a/wb_modbus/bindings.py
+++ b/wb_modbus/bindings.py
@@ -564,6 +564,7 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
 
     FIRMWARE_VERSION_LENGTH = 16  # 250-265 u16 regs
     DEVICE_SIGNATURE_LENGTH = 6  # 200-205 u16 regs
+    DEVICE_SIGNATURE_EXTENDED_LENGTH = 20  # 200-219 u16 regs
     FIRMWARE_SIGNATURE_LENGTH = 12  # 290-301 u16 regs
     BOOTLOADER_VERSION_LENGTH = 8  # 330-337 u16 regs
 
@@ -729,7 +730,12 @@ class WBModbusDeviceBase(MinimalModbusAPIWrapper):
         :return: device signature string
         :rtype: str
         """
-        return self.read_string(self.COMMON_REGS_MAP["device_signature"], self.DEVICE_SIGNATURE_LENGTH)
+        try:
+            return self.read_string(
+                self.COMMON_REGS_MAP["device_signature"], self.DEVICE_SIGNATURE_EXTENDED_LENGTH
+            )
+        except minimalmodbus.IllegalRequestError:
+            return self.read_string(self.COMMON_REGS_MAP["device_signature"], self.DEVICE_SIGNATURE_LENGTH)
 
     def get_fw_signature(self):
         """


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В бастром модбасе завезли 20 регистров для указания модели, а читалось всегда 6. В результате значение модели устройства у мапов читались не полностью и не срабатывала регулярка.
___________________________________
**Что поменялось для пользователей:**

Коррестно будут обновляться мапы через апдейтер
___________________________________
**Как проверял/а:**

на стенде в офисе
