### PR TITLE
Fix update-fw with WB-MAP*

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mcu-fw-updater (1.14.4) stable; urgency=medium
+
+  * Fix update-fw with wb-MAP* 
+
+ -- ekateluv <ekateluv@ekateluv>  Wed, 04 Mar 2026 13:41:53 +0300
+
 wb-mcu-fw-updater (1.14.3) stable; urgency=medium
 
   * Add extended device model reading for fast modbus devices

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ wb-mcu-fw-updater (1.14.4) stable; urgency=medium
 
   * Fix update-fw with wb-MAP* 
 
- -- ekateluv <ekateluv@ekateluv>  Wed, 04 Mar 2026 13:41:53 +0300
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Wed, 04 Mar 2026 13:41:53 +0300
 
 wb-mcu-fw-updater (1.14.3) stable; urgency=medium
 

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -122,7 +122,7 @@ def _update_alive_device(  # pylint:disable=too-many-arguments,too-many-locals
             if mode != MODE_BOOTLOADER:  # do not update components in update-bl
                 if not update_monitor.wait_for_wake_up(modbus_connection, 0.5):
                     raise ModbusException("Device did not wake up after flashing")
-                
+
                 update_monitor.flash_alive_device_components(
                     modbus_connection, mode, branch, version, force, component_signature
                 )

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -43,7 +43,7 @@ def find_connection_params(slaveid, port, response_timeout, instrument):
         )
 
 
-def _update_alive_device(  # pylint:disable=too-many-arguments,too-many-locals
+def _update_alive_device(  # pylint:disable=too-many-arguments,too-many-locals,too-many-branches
     slaveid,
     port,
     mode,

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -120,6 +120,9 @@ def _update_alive_device(  # pylint:disable=too-many-arguments,too-many-locals
                     modbus_connection, mode, branch, version, force, erase_settings
                 )
             if mode != MODE_BOOTLOADER:  # do not update components in update-bl
+                if not update_monitor.wait_for_wake_up(modbus_connection, 0.5):
+                    raise ModbusException("Device did not wake up after flashing")
+                
                 update_monitor.flash_alive_device_components(
                     modbus_connection, mode, branch, version, force, component_signature
                 )


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
В коде update-fw после прошивки основного wbfw софт идет проверять модель девайсины, чтобы посмотреть на список компонентов. Обычно хватает вобще без задержек перейти от первого ко второму, но забыли что мапы немного тормозят после прошивки, добавили таймаут. Большой (по совету из задачи) делать не стала, сделала как в update_all 0.5с (если что его вобще не было в этом месте).

___________________________________
**Что поменялось для пользователей:**
Не будут появляться ошибки с таймаутом после успешной прошивки мапов

___________________________________
**Как проверял/а:**

на стенде в офисе
