### PR TITLE
recover: source brute-force signature list from release-versions.yaml

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+wb-mcu-fw-updater (1.14.6) stable; urgency=medium
+
+  * recover: take the brute-force fw_signatures candidate list from
+    release-versions.yaml instead of the fw_signatures.txt index, which is being
+    retired. Only signatures with a released firmware are tried now (the rest could
+    not be flashed back anyway), so recovering an unknown-signature device no longer
+    prompts to pull an unreleased master build for every non-released signature
+
+ -- Ilia Skochilov <ilia.skochilov@wirenboard.com>  Mon, 29 Jun 2026 15:31:49 +0300
+
 wb-mcu-fw-updater (1.14.5) stable; urgency=medium
 
   * update-all: skip devices with errors during update

--- a/wb_mcu_fw_updater/__init__.py
+++ b/wb_mcu_fw_updater/__init__.py
@@ -32,7 +32,6 @@ CONFIG = {
     "RELEASES_FNAME": "/usr/lib/wb-release",
     # fw-releases.wirenboard.com endpoints
     "ROOT_URL": "http://fw-releases.wirenboard.com/",
-    "FW_SIGNATURES_FILE_URI": "fw/by-signature/fw_signatures.txt",
     "FW_RELEASES_FILE_URI": "fw/by-signature/release-versions.yaml",
 }
 

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -8,6 +8,7 @@ import sys
 from functools import lru_cache
 
 import six
+import yaml
 from six.moves import urllib
 
 from . import CONFIG, MODE_COMPONENTS, MODE_FW, logger
@@ -63,8 +64,15 @@ def get_remote_releases_info(
 
 
 def get_fw_signatures_list():
-    ret = read_remote_file(urllib.parse.urljoin(CONFIG["ROOT_URL"], CONFIG["FW_SIGNATURES_FILE_URI"]))
-    return ret.split("\n") if ret else None
+    """
+    All fw signatures that have a released firmware, taken from release-versions.yaml
+    (its "releases" mapping is keyed by signature). Used by `recover` to brute-force a
+    device stuck in the bootloader whose signature is unknown: only signatures with a
+    released firmware can actually be flashed back, so that mapping is exactly the set
+    worth trying. Replaces the standalone fw_signatures.txt index, which is being retired.
+    """
+    contents = get_remote_releases_info()
+    return list(yaml.safe_load(contents).get("releases", {})) or None
 
 
 @lru_cache(maxsize=3)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Часть работ по выводу из эксплуатации файла `by-signature/fw_signatures.txt`.

`wb-mcu-fw-updater` читал `fw/by-signature/fw_signatures.txt` в команде `recover`, когда сигнатура застрявшего в загрузчике устройства неизвестна и перебираются все возможные сигнатуры. Теперь список кандидатов берётся из `release-versions.yaml`, который и так скачивается на обычном пути восстановления.

___________________________________
**Что поменялось для пользователей:**

- `recover` без `--fw-sig` для устройства с неизвестной сигнатурой перебирает теперь только сигнатуры, у которых есть **релизная** прошивка (ключи `releases` из `release-versions.yaml`), а не все вообще загруженные на S3.
  - Это ровно те сигнатуры, которые `recover_device_iteration` может реально прошить обратно: для сигнатуры без релиза старый код по каждой такой сигнатуре всё равно упирался в вопрос «скачать из master на свой страх и риск?» (и `die`, если отказать). Теперь при переборе таких вопросов нет.
- Явный путь `recover --fw-sig <signature>` не меняется.
- Нормальное обновление/восстановление по известной сигнатуре не меняется — оно и так шло через `release-versions.yaml`.

___________________________________
**Как проверял/а:**

- `black --check --line-length 110`, `isort --check --profile black`, `pylint --rcfile=pyproject.toml` — чисто, оценка 10.00/10.
- Юнит-тестов в репозитории нет; логику проверил локальным smoke-тестом с monkeypatch `read_remote_file`: на образце `release-versions.yaml` `get_fw_signatures_list()` возвращает ровно ключи секции `releases` (в исходном порядке), обращается к `…/fw/by-signature/release-versions.yaml`, исключает прочие верхнеуровневые ключи и отдаёт `None` при пустом/отсутствующем `releases` (сохранён прежний контракт «пусто → None»).