### PR TITLE
Drive bootloader update and rollback from release-versions.yaml

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+wb-mcu-fw-updater (1.15.0) stable; urgency=medium
+
+  * bootloader updates: pick the actual version from the released
+    boot/by-signature/release-versions.yaml (keyed by signature and the
+    controller's release suite, testing or stable) and compare with the version
+    in the device -- same source of truth as firmwares. update-bl now defaults to
+    the release lookup instead of latest.txt.
+  * bootloader rollback now works like firmwares.
+
+ -- Ilia Skochilov <ilia.skochilov@wirenboard.com>  Tue, 30 Jun 2026 10:44:20 +0300
+
 wb-mcu-fw-updater (1.14.6) stable; urgency=medium
 
   * recover: take the brute-force fw_signatures candidate list from
@@ -16,7 +27,7 @@ wb-mcu-fw-updater (1.14.5) stable; urgency=medium
 
 wb-mcu-fw-updater (1.14.4) stable; urgency=medium
 
-  * Fix update-fw with wb-MAP* 
+  * Fix update-fw with wb-MAP*ё
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Wed, 04 Mar 2026 13:41:53 +0300
 
@@ -28,7 +39,7 @@ wb-mcu-fw-updater (1.14.3) stable; urgency=medium
 
 wb-mcu-fw-updater (1.14.2) stable; urgency=medium
 
-  * Add component signature argument for updating components to version/branch 
+  * Add component signature argument for updating components to version/branch
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Mon, 01 Sep 2025 14:02:06 +0300
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -27,7 +27,7 @@ wb-mcu-fw-updater (1.14.5) stable; urgency=medium
 
 wb-mcu-fw-updater (1.14.4) stable; urgency=medium
 
-  * Fix update-fw with wb-MAP*ё
+  * Fix update-fw with wb-MAP*
 
  -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Wed, 04 Mar 2026 13:41:53 +0300
 

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -159,7 +159,9 @@ def update_fw(args):  # pylint:disable=redefined-outer-name
 
 def update_bootloader(args):  # pylint:disable=redefined-outer-name
     # Could install specified bl_version from specified branch.
-    version = args.specified_version or "latest"  # no bl-releases.yaml yet
+    # Default "release" => suite-aware lookup in boot/by-signature/release-versions.yaml,
+    # mirroring the firmware update path.
+    version = args.specified_version or "release"
     _update_alive_device(
         slaveid=args.slaveid,
         port=args.port,

--- a/wb-mcu-fw-updater
+++ b/wb-mcu-fw-updater
@@ -440,7 +440,9 @@ def parse_args():  # pylint:disable=inconsistent-return-statements
 
     # Updating bootloader on single working device
     update_bootloader_parser = subparsers.add_parser(
-        "update-bl", help="Update bootloader on single working device."
+        "update-bl",
+        help="Update bootloader on single working device "
+        "(to the suite-aware released version; downgrade/rollback allowed).",
     )
     add_common_logic_args(update_bootloader_parser)
     add_modbus_connection_args(update_bootloader_parser)

--- a/wb_mcu_fw_updater/__init__.py
+++ b/wb_mcu_fw_updater/__init__.py
@@ -33,6 +33,7 @@ CONFIG = {
     # fw-releases.wirenboard.com endpoints
     "ROOT_URL": "http://fw-releases.wirenboard.com/",
     "FW_RELEASES_FILE_URI": "fw/by-signature/release-versions.yaml",
+    "BOOT_RELEASES_FILE_URI": "boot/by-signature/release-versions.yaml",
 }
 
 

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -11,7 +11,13 @@ import six
 import yaml
 from six.moves import urllib
 
-from . import CONFIG, MODE_COMPONENTS, MODE_FW, logger
+from . import CONFIG, MODE_BOOTLOADER, MODE_COMPONENTS, MODE_FW, logger
+
+REMOTE_SECTION_BY_MODE = {
+    MODE_FW: "fw",
+    MODE_COMPONENTS: "fw",
+    MODE_BOOTLOADER: "boot",
+}
 
 
 class WBRemoteStorageError(Exception):
@@ -143,9 +149,9 @@ class RemoteFileWatcher:
             CONFIG["COMPONENTS_FW_EXTENSION"] if mode == MODE_COMPONENTS else CONFIG["FW_EXTENSION"]
         )
 
-        url_mode = MODE_FW if mode == MODE_COMPONENTS else mode
+        remote_section = REMOTE_SECTION_BY_MODE.get(mode, mode)
         fw_source = f"unstable/{branch_name}" if branch_name else CONFIG["DEFAULT_SOURCE"]
-        self.parent_url_path = self._join(url_mode, sort_by, "%s", fw_source)  # fw_sig or device_sig
+        self.parent_url_path = self._join(remote_section, sort_by, "%s", fw_source)  # fw_sig or device_sig
 
     def _join(self, *args):
         return "/".join(map(str, args))

--- a/wb_mcu_fw_updater/fw_downloader.py
+++ b/wb_mcu_fw_updater/fw_downloader.py
@@ -169,19 +169,6 @@ class RemoteFileWatcher:
         url_path = urllib.parse.urljoin(CONFIG["ROOT_URL"], remote_path)
         return read_remote_file(url_path)
 
-    def is_version_exist(self, fwsig: str, version: str):
-        """
-        Check, does specified fw/bootloader/component version exist for actual fw_sig.
-        In some cases, buggy fws could be removed from fw-releases.
-        """
-        remote_path = self._join(self.parent_url_path % fwsig, f"{version}{self.extension}")
-        url_path = urllib.parse.urljoin(CONFIG["ROOT_URL"], remote_path)
-        try:
-            get_request(url_path)
-            return True
-        except WBRemoteStorageError:
-            return False
-
     def download(self, name, version="latest"):  # pylint:disable=inconsistent-return-statements
         """
         Downloading a firmware/bootloader file with specified version to specified fname.

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -153,7 +153,7 @@ def get_released_fw(fw_signature, release_info, mode=MODE_FW):
         CONFIG["BOOT_RELEASES_FILE_URI"] if mode == MODE_BOOTLOADER else CONFIG["FW_RELEASES_FILE_URI"]
     )
     default_releases_file_url = urllib.parse.urljoin(CONFIG["ROOT_URL"], releases_file_uri)
-    mode_label = "bootloader" if mode == MODE_BOOTLOADER else "firmware"
+    mode_label = {MODE_BOOTLOADER: "bootloader", MODE_COMPONENTS: "components"}.get(mode, "firmware")
     for url in releases.get_release_file_urls(
         release_info, default_releases_file_url
     ):  # repo-prefix is the first, if exists
@@ -570,20 +570,35 @@ def is_reflash_component_necessary(actual_version, provided_version, force_refla
     return do_flash
 
 
-def is_bootloader_latest(mb_connection):
+def _released_bootloader_versions(mb_connection):
+    """
+    (fw_signature, local, released) bootloader versions, local/released as
+    semantic_version.Version; or None when no bootloader is released for the device's
+    signature/suite. Shared by is_bootloader_latest and is_bl_update_required so both
+    read the same source (boot/by-signature/release-versions.yaml).
+    """
     fw_sig = mb_connection.get_fw_signature()
-    local_version = mb_connection.get_bootloader_version()
     try:
         remote_version, _ = get_released_fw(fw_sig, RELEASE_INFO, mode=MODE_BOOTLOADER)
     except NoReleasedFwError:
+        return None
+    local_version = mb_connection.get_bootloader_version()
+    return fw_sig, semantic_version.Version(local_version), semantic_version.Version(remote_version)
+
+
+def is_bootloader_latest(mb_connection):
+    versions = _released_bootloader_versions(mb_connection)
+    if versions is None:
         return True  # nothing released for this signature/suite -> nothing to offer
-    return semantic_version.Version(local_version) >= semantic_version.Version(remote_version)
+    _, local_version, remote_version = versions
+    return local_version >= remote_version
 
 
 def _do_download(fw_sig, version, branch, mode, retrieve_latest_vnum=True):
     """
     Generic .wbfw downloading logic: ("release" is a default val for version)
         version=="release"; branch==None -> looking into release-versions.yaml (default case)
+            (fw/by-signature/ for fw & components, boot/by-signature/ for bootloader)
         version=="release"; branch==<specified_branch> -> looking into branch/latest
         version==<specified_version>; branch==None -> looking into main/version
         version==<specified_version>; branch==<specified_branch> -> looking into branch/version
@@ -614,7 +629,8 @@ def _do_download(fw_sig, version, branch, mode, retrieve_latest_vnum=True):
     if version == "release":  # triggered updating from releases
         version, released_fw_endpoint = get_released_fw(fw_sig, RELEASE_INFO, mode=mode)
         downloaded_fw = fw_downloader.download_remote_file(
-            six.moves.urllib.parse.urljoin(CONFIG["ROOT_URL"], released_fw_endpoint)
+            six.moves.urllib.parse.urljoin(CONFIG["ROOT_URL"], released_fw_endpoint),
+            saving_dir=os.path.join(CONFIG["FW_SAVING_DIR"], mode),  # keep fw/bl/components apart
         )
     else:
         logger.debug("%s version has specified manually: %s", mode_name, version)
@@ -632,19 +648,16 @@ def is_interactive_shell():
 
 
 def is_bl_update_required(modbus_connection, force=False):
-    fw_sig = modbus_connection.get_fw_signature()
-    local_version = modbus_connection.get_bootloader_version()
-    try:
-        remote_version, _ = get_released_fw(fw_sig, RELEASE_INFO, mode=MODE_BOOTLOADER)
-    except NoReleasedFwError:
+    versions = _released_bootloader_versions(modbus_connection)
+    if versions is None:
         logger.debug(
             "No released bootloader for %s in suite %s; skip bootloader update",
-            fw_sig,
+            modbus_connection.get_fw_signature(),
             RELEASE_INFO.get("SUITE"),
         )
         return False
-
-    if semantic_version.Version(local_version) >= semantic_version.Version(remote_version):
+    fw_sig, local_version, remote_version = versions
+    if local_version >= remote_version:
         return False
 
     suggestion_str = (

--- a/wb_mcu_fw_updater/update_monitor.py
+++ b/wb_mcu_fw_updater/update_monitor.py
@@ -137,17 +137,26 @@ def fill_release_info():
         six.reraise(*sys.exc_info())
 
 
-def get_released_fw(fw_signature, release_info):
+def get_released_fw(fw_signature, release_info, mode=MODE_FW):
     """
-    Looking for released-fw:
+    Looking for released firmware/bootloader:
         version
         url on fw-releases
     By:
         fw_signature
         release suite
+        mode (firmwares and bootloaders have separate release-versions.yaml files,
+        both keyed by signature and suite)
     """
     suite = release_info["SUITE"]
-    for url in releases.get_release_file_urls(release_info):  # repo-prefix is the first, if exists
+    releases_file_uri = (
+        CONFIG["BOOT_RELEASES_FILE_URI"] if mode == MODE_BOOTLOADER else CONFIG["FW_RELEASES_FILE_URI"]
+    )
+    default_releases_file_url = urllib.parse.urljoin(CONFIG["ROOT_URL"], releases_file_uri)
+    mode_label = "bootloader" if mode == MODE_BOOTLOADER else "firmware"
+    for url in releases.get_release_file_urls(
+        release_info, default_releases_file_url
+    ):  # repo-prefix is the first, if exists
         logger.debug("Looking to %s (suite: %s)", url, str(suite))
         try:
             contents = fw_downloader.get_remote_releases_info(url)
@@ -155,7 +164,8 @@ def get_released_fw(fw_signature, release_info):
             if fw_endpoint:
                 fw_version = releases.parse_fw_version(fw_endpoint)
                 logger.debug(
-                    "FW version for %s on release %s: %s (endpoint: %s)",
+                    "%s version for %s on release %s: %s (endpoint: %s)",
+                    mode_label,
                     fw_signature,
                     suite,
                     fw_version,
@@ -163,11 +173,11 @@ def get_released_fw(fw_signature, release_info):
                 )
                 return str(fw_version), str(fw_endpoint)
         except fw_downloader.RemoteFileReadingError:
-            logger.warning('No released fw for "%s" in "%s"', fw_signature, url)
+            logger.warning('No released %s for "%s" in "%s"', mode_label, fw_signature, url)
         except releases.VersionParsingError as e:
             logger.exception(e)
     raise NoReleasedFwError(
-        f'Released FW not found for "{fw_signature}"\n'
+        f'Released {mode_label} not found for "{fw_signature}"\n'
         "Release info:\n"
         f"{json.dumps(release_info, indent=4)}"
     )
@@ -563,8 +573,11 @@ def is_reflash_component_necessary(actual_version, provided_version, force_refla
 def is_bootloader_latest(mb_connection):
     fw_sig = mb_connection.get_fw_signature()
     local_version = mb_connection.get_bootloader_version()
-    remote_version = fw_downloader.RemoteFileWatcher(mode=MODE_BOOTLOADER).get_latest_version_number(fw_sig)
-    return semantic_version.Version(local_version) == semantic_version.Version(remote_version)
+    try:
+        remote_version, _ = get_released_fw(fw_sig, RELEASE_INFO, mode=MODE_BOOTLOADER)
+    except NoReleasedFwError:
+        return True  # nothing released for this signature/suite -> nothing to offer
+    return semantic_version.Version(local_version) >= semantic_version.Version(remote_version)
 
 
 def _do_download(fw_sig, version, branch, mode, retrieve_latest_vnum=True):
@@ -599,7 +612,7 @@ def _do_download(fw_sig, version, branch, mode, retrieve_latest_vnum=True):
             # instead of "retrieve_latest_vnum" logic?
 
     if version == "release":  # triggered updating from releases
-        version, released_fw_endpoint = get_released_fw(fw_sig, RELEASE_INFO)
+        version, released_fw_endpoint = get_released_fw(fw_sig, RELEASE_INFO, mode=mode)
         downloaded_fw = fw_downloader.download_remote_file(
             six.moves.urllib.parse.urljoin(CONFIG["ROOT_URL"], released_fw_endpoint)
         )
@@ -621,23 +634,21 @@ def is_interactive_shell():
 def is_bl_update_required(modbus_connection, force=False):
     fw_sig = modbus_connection.get_fw_signature()
     local_version = modbus_connection.get_bootloader_version()
-    remote_file_watcher = fw_downloader.RemoteFileWatcher(mode=MODE_BOOTLOADER)
-    latest_remote_version = remote_file_watcher.get_latest_version_number(fw_sig)
-
-    if semantic_version.Version(local_version) == semantic_version.Version(latest_remote_version):
+    try:
+        remote_version, _ = get_released_fw(fw_sig, RELEASE_INFO, mode=MODE_BOOTLOADER)
+    except NoReleasedFwError:
+        logger.debug(
+            "No released bootloader for %s in suite %s; skip bootloader update",
+            fw_sig,
+            RELEASE_INFO.get("SUITE"),
+        )
         return False
 
-    if not remote_file_watcher.is_version_exist(fw_sig, local_version):
-        logger.warning(
-            "Local bootloader version v%s is not found on remote! (maybe was removed manually) => "
-            "Will update bootloader to latest v%s anyway!",
-            local_version,
-            latest_remote_version,
-        )
-        return True
+    if semantic_version.Version(local_version) >= semantic_version.Version(remote_version):
+        return False
 
     suggestion_str = (
-        f"Bootloader update (v{local_version} -> v{latest_remote_version}) for {fw_sig} "
+        f"Bootloader update (v{local_version} -> v{remote_version}) for {fw_sig} "
         f"{modbus_connection.port}:{modbus_connection.slaveid} is available! "
         "(bootloader updates are highly recommended to install)"
     )
@@ -653,14 +664,14 @@ def _do_flash(modbus_connection, downloaded_wbfw: DownloadedWBFW, erase_settings
     logger.debug("Flashing approved for %s", device_str)
     bl_to_flash = None
     actual_bl_version = modbus_connection.get_bootloader_version()
+    # Bootloader downgrade is allowed and mirrors firmware: the up/down/keep decision is
+    # made by is_reflash_necessary (allow_downgrade) in flash_alive_device, so an explicit
+    # `update-bl` rolls a device back to the version pinned in the released
+    # boot/by-signature/release-versions.yaml -- lower the pin to roll bootloaders back in
+    # the field (no hard guard anymore, same as firmwares).
     if downloaded_wbfw.mode == MODE_FW:
         if is_bl_update_required(modbus_connection, force):
-            bl_to_flash = fw_downloader.RemoteFileWatcher(MODE_BOOTLOADER).download(fw_signature, "latest")
-    elif downloaded_wbfw.mode == MODE_BOOTLOADER:
-        if semantic_version.Version(downloaded_wbfw.version) < semantic_version.Version(actual_bl_version):
-            raise UpdateDeviceError(
-                f"Bootloader downgrade (v{actual_bl_version} -> v{downloaded_wbfw.version}) is not allowed!"
-            )
+            bl_to_flash = _do_download(fw_signature, "release", None, MODE_BOOTLOADER).fpath
 
     do_check_userdata_saving = semantic_version.Version(actual_bl_version) >= semantic_version.Version(
         "1.2.0"


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Актуальная версия загрузчиков теперь берется из  boot/by-signature/release-versions.yaml (аналогично прошивкам).

___________________________________
**Что поменялось для пользователей:**

- `update-bl` и проверки версии загрузчика теперь берут актуальную версию из `boot/by-signature/release-versions.yaml` по релизу контроллера (testing/stable).
- **Откат загрузчиков работает как у прошивок.** Убран жёсткий запрет даунгрейда: одиночный `update-bl` зальёт ту версию, что закреплена в релизе. Обновление загрузчика во время `update-fw`/`update-all` и подсказка «bl update available» остаются «только upgrade».
- Все скачивания загрузчиков (`release`, `--branch`, `--version`) теперь идут в актуальный префикс `boot/`.
___________________________________
**Как проверял/а:**

- Статика: `py_compile`, `black`, `isort`, `pylint` (конфиг репозитория) — чисто, 10.00/10.
- На локальном контроллере проверил upgrade и downgrade загрузчика ledG.
